### PR TITLE
[Fix] Revise channel_order in low-level vision metrics

### DIFF
--- a/mmeval/metrics/psnr.py
+++ b/mmeval/metrics/psnr.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import logging
 import numpy as np
 from typing import Dict, List, Optional, Sequence
 
@@ -67,6 +68,7 @@ class PSNR(BaseMetric):
         self.input_order = input_order
         self.convert_to = convert_to
         self.channel_order = channel_order
+        self._channel_order_warning_raised = False
 
     def add(self, predictions: Sequence[np.ndarray], groundtruths: Sequence[np.ndarray], channel_order: Optional[str] = None) -> None:  # type: ignore # yapf: disable # noqa: E501
         """Add PSNR score of batch to ``self._results``
@@ -81,6 +83,12 @@ class PSNR(BaseMetric):
 
         if channel_order is None:
             channel_order = self.channel_order
+        else:
+            if (self.channel_order is not None
+                    and channel_order != self.channel_order):
+                logging.warning(
+                    f'Input \'channel_order\'({channel_order}) is different '
+                    f'from \'self.channel_order\'({self.channel_order}).')
 
         for prediction, groundtruth in zip(predictions, groundtruths):
             assert groundtruth.shape == prediction.shape, (
@@ -91,13 +99,13 @@ class PSNR(BaseMetric):
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
             prediction = reorder_and_crop(
                 prediction,
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
 
             self._results.append(self.compute_psnr(prediction, groundtruth))
 

--- a/mmeval/metrics/snr.py
+++ b/mmeval/metrics/snr.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import logging
 import numpy as np
 from typing import Dict, List, Optional, Sequence
 
@@ -79,8 +80,15 @@ class SNR(BaseMetric):
                 samples. If not passed, will set as :attr:`self.channel_order`.
                 Defaults to None.
         """
-        channel_order = self.channel_order \
-            if channel_order is None else channel_order
+        if channel_order is None:
+            channel_order = self.channel_order
+        else:
+            if (self.channel_order is not None
+                    and channel_order != self.channel_order):
+                logging.warning(
+                    f'Input \'channel_order\'({channel_order}) is different '
+                    f'from \'self.channel_order\'({self.channel_order}).')
+
         for pred, gt in zip(predictions, groundtruths):
             assert gt.shape == pred.shape, (
                 f'Image shapes are different: {gt.shape}, {pred.shape}.')
@@ -89,13 +97,13 @@ class SNR(BaseMetric):
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
             pred = reorder_and_crop(
                 pred,
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
 
             self._results.append(self.compute_snr(pred, gt))
 

--- a/mmeval/metrics/ssim.py
+++ b/mmeval/metrics/ssim.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import logging
 import numpy as np
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
@@ -94,8 +95,14 @@ class SSIM(BaseMetric):
                 samples. If not passed, will set as :attr:`self.channel_order`.
                 Defaults to None.
         """
-        channel_order = self.channel_order \
-            if channel_order is None else channel_order
+        if channel_order is None:
+            channel_order = self.channel_order
+        else:
+            if (self.channel_order is not None
+                    and channel_order != self.channel_order):
+                logging.warning(
+                    f'Input \'channel_order\'({channel_order}) is different '
+                    f'from \'self.channel_order\'({self.channel_order}).')
 
         for pred, gt in zip(predictions, groundtruths):
             assert pred.shape == gt.shape, (

--- a/tests/test_metrics/test_psnr.py
+++ b/tests/test_metrics/test_psnr.py
@@ -70,4 +70,5 @@ def test_psnr_channel_order_checking(caplog):
                Mock(return_value=np.ones((32, 32)))) as process_fn:
         psnr.add(img1, img2, channel_order='BGR')
     assert target_warn_msg in caplog.text
-    assert process_fn.call_args.kwargs['channel_order'] == 'BGR'
+    _, kwargs = process_fn.call_args
+    assert kwargs['channel_order'] == 'BGR'

--- a/tests/test_metrics/test_snr.py
+++ b/tests/test_metrics/test_snr.py
@@ -59,4 +59,5 @@ def test_psnr_channel_order_checking(caplog):
                Mock(return_value=np.ones((32, 32)))) as process_fn:
         snr.add(img1, img2, channel_order='BGR')
     assert target_warn_msg in caplog.text
-    assert process_fn.call_args.kwargs['channel_order'] == 'BGR'
+    _, kwargs = process_fn.call_args
+    assert kwargs['channel_order'] == 'BGR'

--- a/tests/test_metrics/test_ssim.py
+++ b/tests/test_metrics/test_ssim.py
@@ -56,4 +56,5 @@ def test_psnr_channel_order_checking(caplog):
                Mock(return_value=np.ones((3, 32, 32)))) as process_fn:
         ssim.add(img1, img2, channel_order='BGR')
     assert target_warn_msg in caplog.text
-    assert process_fn.call_args.kwargs['channel_order'] == 'BGR'
+    _, kwargs = process_fn.call_args
+    assert kwargs['channel_order'] == 'BGR'

--- a/tests/test_metrics/test_ssim.py
+++ b/tests/test_metrics/test_ssim.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from unittest.mock import Mock, patch
 
 from mmeval.metrics import SSIM
 
@@ -44,3 +45,15 @@ def test_ssim(metric_kwargs, img1, img2, results):
     ssim_results = ssim(img1, img2)
     assert isinstance(ssim_results, dict)
     np.testing.assert_almost_equal(ssim_results['ssim'], results)
+
+
+def test_psnr_channel_order_checking(caplog):
+    ssim = SSIM(crop_border=0, channel_order='RGB')
+    img1, img2 = [np.ones((32, 32))], [np.ones((32, 32)) * 2]
+    target_warn_msg = ('Input \'channel_order\'(BGR) is different '
+                       'from \'self.channel_order\'(RGB).')
+    with patch('mmeval.metrics.ssim.reorder_and_crop',
+               Mock(return_value=np.ones((3, 32, 32)))) as process_fn:
+        ssim.add(img1, img2, channel_order='BGR')
+    assert target_warn_msg in caplog.text
+    assert process_fn.call_args.kwargs['channel_order'] == 'BGR'


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Refers to issue #51 .

## Modification

Revise `self.channel_order` to `channel_order` in `add` function, and add warning when `self.channel_order` is different from passed `channel_order`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
