### PR TITLE
add oneflow backend for mmeval

### DIFF
--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -201,10 +201,10 @@ accuracy.compute()
 
 ## 欢迎加入 OpenMMLab 社区
 
-扫描下方的二维码可关注 OpenMMLab 团队的 [知乎官方账号](https://www.zhihu.com/people/openmmlab)，加入 OpenMMLab 团队的 [官方交流 QQ 群](https://jq.qq.com/?_wv=1027&k=aCvMxdr3)，或通过添加微信“Open小喵Lab”加入官方交流微信群。
+扫描下方的二维码可关注 OpenMMLab 团队的 [知乎官方账号](https://www.zhihu.com/people/openmmlab)，加入 OpenMMLab 团队的 [官方交流 QQ 群](https://jq.qq.com/?_wv=1027&k=K0QI8ByU)，或通过添加微信“Open小喵Lab”加入官方交流微信群。
 
 <div align="center">
-<img src="https://user-images.githubusercontent.com/58739961/187154320-f3312cdf-31f2-4316-9dbb-8d7b0e1b7e08.jpg" height="400" />  <img src="https://user-images.githubusercontent.com/58739961/187151554-1a0748f0-a1bb-4565-84a6-ab3040247ef1.jpg" height="400" />  <img src="https://user-images.githubusercontent.com/58739961/187151778-d17c1368-125f-4fde-adbe-38cc6eb3be98.jpg" height="400" />
+<img src="https://user-images.githubusercontent.com/58739961/187154320-f3312cdf-31f2-4316-9dbb-8d7b0e1b7e08.jpg" height="400" />  <img src="https://user-images.githubusercontent.com/25839884/203904835-62392033-02d4-4c73-a68c-c9e4c1e2b07f.jpg" height="400" />  <img src="https://user-images.githubusercontent.com/58739961/187151778-d17c1368-125f-4fde-adbe-38cc6eb3be98.jpg" height="400" />
 </div>
 
 我们会在 OpenMMLab 社区为大家

--- a/mmeval/metrics/accuracy.py
+++ b/mmeval/metrics/accuracy.py
@@ -32,10 +32,10 @@ def _is_scalar(obj: np.number):  # type: ignore
 @overload
 @dispatch
 def _is_scalar(obj: Union[np.ndarray,  # type: ignore
-                          'torch.Tensor', 'oneflow.Tensor',
+                          'torch.Tensor', 
+                          'oneflow.Tensor',
                           'tensorflow.Tensor']):
     """Check if a ``np.ndarray`` | ``torch.Tensor`` | ``oneflow.Tensor``
-
     |``tensorflow.Tensor`` is a scalar.
     """
     return obj.ndim == 0

--- a/mmeval/metrics/accuracy.py
+++ b/mmeval/metrics/accuracy.py
@@ -105,7 +105,7 @@ class Accuracy(BaseMetric):
     This metric computes the accuracy based on the given topk and thresholds.
 
     Currently, this metric supports 5 kinds of inputs, i.e. ``numpy.ndarray``,
-    ``torch.Tensor``, ``OneFlow.Tensor``, ``tensorflow.Tensor`` and
+    ``torch.Tensor``, ``oneflow.Tensor``, ``tensorflow.Tensor`` and
     ``paddle.Tensor``, and the implementation for the calculation depends on
     the inputs type.
 

--- a/mmeval/metrics/accuracy.py
+++ b/mmeval/metrics/accuracy.py
@@ -32,10 +32,10 @@ def _is_scalar(obj: np.number):  # type: ignore
 @overload
 @dispatch
 def _is_scalar(obj: Union[np.ndarray,  # type: ignore
-                          'torch.Tensor', 
-                          'oneflow.Tensor',
+                          'torch.Tensor', 'oneflow.Tensor',
                           'tensorflow.Tensor']):
     """Check if a ``np.ndarray`` | ``torch.Tensor`` | ``oneflow.Tensor``
+
     |``tensorflow.Tensor`` is a scalar.
     """
     return obj.ndim == 0

--- a/mmeval/metrics/end_point_error.py
+++ b/mmeval/metrics/end_point_error.py
@@ -125,7 +125,7 @@ class EndPointError(BaseMetric):
         epe = epe_map.reshape(-1)[val]
         return epe.mean(keepdims=True), int(val.sum())
 
-    @dispatch
+    @dispatch  # type: ignore
     def end_point_error_map(  # type: ignore
             self,
             prediction: 'torch.Tensor',
@@ -149,7 +149,7 @@ class EndPointError(BaseMetric):
         epe = epe_map.reshape(-1)[val]
         return epe.mean().cpu().numpy(), int(val.sum())
 
-    @dispatch
+    @dispatch  # noqa: F811
     def end_point_error_map(  # type: ignore
         self,
         prediction: 'oneflow.Tensor',

--- a/mmeval/metrics/end_point_error.py
+++ b/mmeval/metrics/end_point_error.py
@@ -22,7 +22,7 @@ class EndPointError(BaseMetric):
     EndPointError is a widely used evaluation metric for optical flow
     estimation.
 
-    This metric supports 2 kinds of inputs, i.e. `numpy.ndarray` and
+    This metric supports 3 kinds of inputs, i.e. `numpy.ndarray` and
     `torch.Tensor`, `oneflow.Tensor`, and the implementation for the
     calculation depends on the inputs type.
 
@@ -127,11 +127,11 @@ class EndPointError(BaseMetric):
 
     @dispatch  # type: ignore
     def end_point_error_map(  # type: ignore
-            self,
-            prediction: 'torch.Tensor',
-            label: 'torch.Tensor',
-            valid_mask: Optional['torch.Tensor'] = None) -> Tuple[np.ndarray,
-                                                                  int]:
+        self,
+        prediction: 'torch.Tensor',
+        label: 'torch.Tensor',
+        valid_mask: Optional['torch.Tensor'] = None
+    ) -> Tuple[np.ndarray, int]:  # type: ignore
         """Calculate end point error map.
 
         Args:

--- a/mmeval/metrics/end_point_error.py
+++ b/mmeval/metrics/end_point_error.py
@@ -126,12 +126,12 @@ class EndPointError(BaseMetric):
         return epe.mean(keepdims=True), int(val.sum())
 
     @dispatch  # type: ignore
-    def end_point_error_map(  # type: ignore
-        self,
-        prediction: 'torch.Tensor',
-        label: 'torch.Tensor',
-        valid_mask: Optional['torch.Tensor'] = None
-    ) -> Tuple[np.ndarray, int]:  # type: ignore
+    def end_point_error_map(
+            self,
+            prediction: 'torch.Tensor',
+            label: 'torch.Tensor',
+            valid_mask: Optional['torch.Tensor'] = None
+    ) -> Tuple[np.ndarray, int]:
         """Calculate end point error map.
 
         Args:
@@ -150,12 +150,12 @@ class EndPointError(BaseMetric):
         return epe.mean().cpu().numpy(), int(val.sum())
 
     @dispatch  # noqa: F811
-    def end_point_error_map(  # type: ignore
+    def end_point_error_map(
         self,
         prediction: 'oneflow.Tensor',
         label: 'oneflow.Tensor',
-        valid_mask: Optional['oneflow.Tensor'] = None) -> Tuple[np.ndarray,
-                                                                int]:
+        valid_mask: Optional['oneflow.Tensor'] = None
+    ) -> Tuple[np.ndarray, int]:
         """Calculate end point error map.
 
         Args:

--- a/mmeval/metrics/end_point_error.py
+++ b/mmeval/metrics/end_point_error.py
@@ -8,8 +8,9 @@ from mmeval.core.dispatcher import dispatch
 from mmeval.utils import try_import
 
 if TYPE_CHECKING:
-    import torch
+    import oneflow
     import oneflow as flow
+    import torch
 else:
     torch = try_import('torch')
     flow = try_import('oneflow')
@@ -22,8 +23,8 @@ class EndPointError(BaseMetric):
     estimation.
 
     This metric supports 2 kinds of inputs, i.e. `numpy.ndarray` and
-    `torch.Tensor`, `oneflow.Tensor`, and the implementation for the calculation depends on
-    the inputs type.
+    `torch.Tensor`, `oneflow.Tensor`, and the implementation for the
+    calculation depends on the inputs type.
 
     Args:
         **kwargs: Keyword arguments passed to :class:`BaseMetric`.
@@ -125,12 +126,12 @@ class EndPointError(BaseMetric):
         return epe.mean(keepdims=True), int(val.sum())
 
     @dispatch
-    def end_point_error_map(
+    def end_point_error_map(  # type: ignore
             self,
             prediction: 'torch.Tensor',
             label: 'torch.Tensor',
-            valid_mask: Optional['torch.Tensor'] = None
-    ) -> Tuple[np.ndarray, int]:
+            valid_mask: Optional['torch.Tensor'] = None) -> Tuple[np.ndarray,
+                                                                  int]:
         """Calculate end point error map.
 
         Args:
@@ -149,18 +150,19 @@ class EndPointError(BaseMetric):
         return epe.mean().cpu().numpy(), int(val.sum())
 
     @dispatch
-    def end_point_error_map(
-            self,
-            prediction: 'oneflow.Tensor',
-            label: 'oneflow.Tensor',
-            valid_mask: Optional['oneflow.Tensor'] = None
-    ) -> Tuple[np.ndarray, int]:
+    def end_point_error_map(  # type: ignore
+        self,
+        prediction: 'oneflow.Tensor',
+        label: 'oneflow.Tensor',
+        valid_mask: Optional['oneflow.Tensor'] = None) -> Tuple[np.ndarray,
+                                                                int]:
         """Calculate end point error map.
 
         Args:
             prediction (oneflow.Tensor): Prediction with shape (H, W, 2).
             label (oneflow.Tensor): Ground truth with shape (H, W, 2).
-            valid_mask (oneflow.Tensor, optional): Valid mask with shape (H, W).
+            valid_mask (oneflow.Tensor, optional):
+                Valid mask with shape (H, W).
 
         Returns:
             Tuple: The mean of end point error and the numbers of valid labels.

--- a/mmeval/metrics/f_metric.py
+++ b/mmeval/metrics/f_metric.py
@@ -7,8 +7,9 @@ from mmeval.core.dispatcher import dispatch
 from mmeval.utils import try_import
 
 if TYPE_CHECKING:
-    import torch
+    import oneflow
     import oneflow as flow
+    import torch
 else:
     torch = try_import('torch')
     flow = try_import('oneflow')
@@ -154,8 +155,9 @@ class F1Metric(BaseMetric):
 
     @overload  # type: ignore
     @dispatch
-    def _compute_tp_fp_fn(self, predictions: Sequence['oneflow.Tensor'],
-                          labels: Sequence['oneflow.Tensor']) -> tuple:
+    def _compute_tp_fp_fn(  # type: ignore
+            self, predictions: Sequence['oneflow.Tensor'],
+            labels: Sequence['oneflow.Tensor']) -> tuple:
         """Compute tp, fp and fn from predictions and labels."""
         preds = flow.cat(predictions).long().flatten().cpu()
         gts = flow.cat(labels).long().flatten().cpu()

--- a/mmeval/metrics/f_metric.py
+++ b/mmeval/metrics/f_metric.py
@@ -8,8 +8,10 @@ from mmeval.utils import try_import
 
 if TYPE_CHECKING:
     import torch
+    import oneflow as flow
 else:
     torch = try_import('torch')
+    flow = try_import('oneflow')
 
 
 class F1Metric(BaseMetric):
@@ -140,6 +142,28 @@ class F1Metric(BaseMetric):
         assert gts.max() < self.num_classes
 
         cared_labels = preds.new_tensor(self.cared_labels, dtype=torch.long)
+
+        hits = (preds == gts)[None, :]
+        preds_per_label = cared_labels[:, None] == preds[None, :]
+        gts_per_label = cared_labels[:, None] == gts[None, :]
+
+        tp = (hits * preds_per_label).cpu().numpy().astype(float)
+        fp = (~hits * preds_per_label).cpu().numpy().astype(float)
+        fn = (~hits * gts_per_label).cpu().numpy().astype(float)
+        return tp, fp, fn
+
+    @overload  # type: ignore
+    @dispatch
+    def _compute_tp_fp_fn(self, predictions: Sequence['oneflow.Tensor'],
+                          labels: Sequence['oneflow.Tensor']) -> tuple:
+        """Compute tp, fp and fn from predictions and labels."""
+        preds = flow.cat(predictions).long().flatten().cpu()
+        gts = flow.cat(labels).long().flatten().cpu()
+
+        assert preds.max() < self.num_classes
+        assert gts.max() < self.num_classes
+
+        cared_labels = preds.new_tensor(self.cared_labels, dtype=flow.long)
 
         hits = (preds == gts)[None, :]
         preds_per_label = cared_labels[:, None] == preds[None, :]

--- a/mmeval/metrics/mean_iou.py
+++ b/mmeval/metrics/mean_iou.py
@@ -8,11 +8,12 @@ from mmeval.core.dispatcher import dispatch
 from mmeval.utils import try_import
 
 if TYPE_CHECKING:
+    import oneflow
+    import oneflow as flow
     import paddle
     import tensorflow
     import tensorflow as tf
     import torch
-    import oneflow as flow
 else:
     paddle = try_import('paddle')
     torch = try_import('torch')
@@ -29,8 +30,9 @@ class MeanIoU(BaseMetric):
     accuracy, mean dice, mean precision, mean recall and mean f-score.
 
     This metric supports 4 kinds of inputs, i.e. ``numpy.ndarray``,
-    ``torch.Tensor``, ``oneflow.Tensor``, ``tensorflow.Tensor`` and ``paddle.Tensor``, and the
-    implementation for the calculation depends on the inputs type.
+    ``torch.Tensor``, ``oneflow.Tensor``, ``tensorflow.Tensor`` and
+    ``paddle.Tensor``, and the implementation for the calculation depends
+    on the inputs type.
 
     Args:
         num_classes (int, optional): The number of classes. If None, it will be

--- a/mmeval/metrics/mean_iou.py
+++ b/mmeval/metrics/mean_iou.py
@@ -29,7 +29,7 @@ class MeanIoU(BaseMetric):
     In addition to mean iou, it will also compute and return accuracy, mean
     accuracy, mean dice, mean precision, mean recall and mean f-score.
 
-    This metric supports 4 kinds of inputs, i.e. ``numpy.ndarray``,
+    This metric supports 5 kinds of inputs, i.e. ``numpy.ndarray``,
     ``torch.Tensor``, ``oneflow.Tensor``, ``tensorflow.Tensor`` and
     ``paddle.Tensor``, and the implementation for the calculation depends
     on the inputs type.

--- a/mmeval/metrics/multi_label.py
+++ b/mmeval/metrics/multi_label.py
@@ -844,6 +844,7 @@ class AveragePrecision(MultiLabelMixin, BaseMetric):
         PyTorch and OneFlow. Which implementation to use is determined by the
         type of the calling parameters. e.g. `numpy.ndarray` or
         `torch.Tensor`, `oneflow.Tensor`.
+
         This method would be invoked in `BaseMetric.compute` after distributed
         synchronization.
         Args:

--- a/mmeval/metrics/multi_label.py
+++ b/mmeval/metrics/multi_label.py
@@ -10,8 +10,9 @@ from mmeval.utils import try_import
 from .single_label import _precision_recall_f1_support
 
 if TYPE_CHECKING:
-    import torch
+    import oneflow
     import oneflow as flow
+    import torch
 else:
     torch = try_import('torch')
     flow = try_import('oneflow')
@@ -24,17 +25,20 @@ BUILTIN_IMPL_HINTS = Tuple[Union[int, Sequence[Union[int, float]]],
                            Union[int, Sequence[int]]]
 
 
-def label_to_onehot(label: Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor'],
-                    num_classes: int) -> Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor']:
+def label_to_onehot(
+        label: Union[np.ndarray, 'torch.Tensor',
+                     'oneflow.Tensor'], num_classes: int
+) -> Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor']:
     """Convert the label-format input to one-hot encodings.
 
     Args:
-        label (torch.Tensor or oneflow.Tensor or np.ndarray): The label-format input.
-            The format of item must be label-format.
+        label (torch.Tensor or oneflow.Tensor or np.ndarray):
+            The label-format input. The format of item must be label-format.
         num_classes (int): The number of classes.
 
     Return:
-        torch.Tensor or oneflow.Tensor or np.ndarray: The converted one-hot encodings.
+        torch.Tensor or oneflow.Tensor or np.ndarray:
+            The converted one-hot encodings.
     """
     if torch and isinstance(label, torch.Tensor):
         label = label.long()
@@ -52,22 +56,26 @@ def label_to_onehot(label: Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor'],
     return onehot
 
 
-def format_data(data: Union[Sequence[Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor']],
-                            np.ndarray, 'torch.Tensor', 'oneflow.Tensor'],
-                num_classes: int,
-                is_onehot: bool = False) -> Union[np.ndarray, 'torch.Tensor', 'flow.Tensor']:
+def format_data(
+    data: Union[Sequence[Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor']],
+                np.ndarray, 'torch.Tensor', 'oneflow.Tensor'],
+    num_classes: int,
+    is_onehot: bool = False
+) -> Union[np.ndarray, 'torch.Tensor', 'oneflow.Tensor']:
     """Format data from different inputs such as prediction scores, label-
     format data and one-hot encodings into the same output shape of `(N,
     num_classes)`.
 
     Args:
-        data (Union[Sequence[np.ndarray, 'torch.Tensor', 'oneflow.Tensor'], np.ndarray,
-            'torch.Tensor']): The input data of prediction or labels.
+        data (Union[Sequence[np.ndarray, 'torch.Tensor', 'oneflow.Tensor'],
+        np.ndarray, 'torch.Tensor', 'oneflow.Tensor']):
+            The input data of prediction or labels.
         num_classes (int): The number of classes.
         is_onehot (bool): Whether the data is one-hot encodings.
 
     Return:
-        torch.Tensor or oneflow.Tensor or np.ndarray: One-hot encodings or predict scores.
+        torch.Tensor or oneflow.Tensor or np.ndarray:
+            One-hot encodings or predict scores.
     """
     if torch and isinstance(data[0], torch.Tensor):
         stack_func = torch.stack
@@ -397,10 +405,11 @@ class MultiLabelMetric(MultiLabelMixin, BaseMetric):
         return _precision_recall_f1_support(  # type: ignore
             pos_inds, labels, self.average)
 
-    @overload
+    @overload  # type: ignore
     @dispatch
-    def _compute_metric(self, predictions: Sequence['oneflow.Tensor'],
-                        labels: Sequence['oneflow.Tensor']) -> List:
+    def _compute_metric(  # type: ignore
+            self, predictions: Sequence['oneflow.Tensor'],
+            labels: Sequence['oneflow.Tensor']) -> List:
         """A OneFlow implementation that computes the metric."""
 
         preds = format_data(predictions, self.num_classes,
@@ -471,20 +480,23 @@ class MultiLabelMetric(MultiLabelMixin, BaseMetric):
             pos_inds, labels, self.average)
 
     def compute_metric(
-        self, results: List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS, ONEFLOW_IMPL_HINTS,
-                                  BUILTIN_IMPL_HINTS]]
+        self, results: List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS,
+                                  ONEFLOW_IMPL_HINTS, BUILTIN_IMPL_HINTS]]
     ) -> Dict[str, float]:
         """Compute the metric.
 
         Currently, there are 3 implementations of this method: NumPy and
-        PyTorch and ONeFlow. Which implementation to use is determined by the type of the
-        calling parameters. e.g. `numpy.ndarray` or `torch.Tensor` or `oneflow.Tensor`.
+        PyTorch and OneFlow. Which implementation to use is determined by the
+        type of the calling parameters. e.g. `numpy.ndarray` or `torch.Tensor`
+        or `oneflow.Tensor`.
         This method would be invoked in `BaseMetric.compute` after distributed
         synchronization.
+
         Args:
-            results (List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS, ONEFLOW_IMPL_HINTS]]): A list
-                of tuples that consisting the prediction and label. This list
-                has already been synced across all ranks.
+            results (List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS,
+            ONEFLOW_IMPL_HINTS]]): A listof tuples that consisting the
+            prediction and label. This list has already been synced across all
+            ranks.
         Returns:
             Dict[str, float]: The computed metric.
         """
@@ -540,8 +552,9 @@ def _average_precision_torch(preds: 'torch.Tensor', labels: 'torch.Tensor',
         return ap * 100
 
 
-def _average_precision_oneflow(preds: 'oneflow.Tensor', labels: 'oneflow.Tensor',
-                             average) -> 'oneflow.Tensor':
+def _average_precision_oneflow(preds: 'oneflow.Tensor',
+                               labels: 'oneflow.Tensor',
+                               average) -> 'oneflow.Tensor':
     r"""Calculate the average precision for oneflow.
 
     AP summarizes a precision-recall curve as the weighted mean of maximum
@@ -584,6 +597,7 @@ def _average_precision_oneflow(preds: 'oneflow.Tensor', labels: 'oneflow.Tensor'
         return ap.mean() * 100.0
     else:
         return ap * 100
+
 
 def _average_precision(preds: np.ndarray, labels: np.ndarray,
                        average) -> np.ndarray:
@@ -775,11 +789,12 @@ class AveragePrecision(MultiLabelMixin, BaseMetric):
             f'({preds.shape[0]}) and labels ({labels.shape[0]}).'
 
         return _average_precision_torch(preds, labels, self.average)
-    
-    @overload
+
+    @overload  # type: ignore
     @dispatch
-    def _compute_metric(self, preds: Sequence['oneflow.Tensor'],
-                        labels: Sequence['oneflow.Tensor']) -> List[List]:
+    def _compute_metric(  # type: ignore
+            self, preds: Sequence['oneflow.Tensor'],
+            labels: Sequence['oneflow.Tensor']) -> List[List]:
         """A OneFlow implementation that computes the metric."""
 
         preds = flow.stack(preds)
@@ -820,20 +835,22 @@ class AveragePrecision(MultiLabelMixin, BaseMetric):
         return _average_precision(preds, labels, self.average)
 
     def compute_metric(
-        self, results: List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS, ONEFLOW_IMPL_HINTS,
-                                  BUILTIN_IMPL_HINTS]]
+        self, results: List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS,
+                                  ONEFLOW_IMPL_HINTS, BUILTIN_IMPL_HINTS]]
     ) -> Dict[str, float]:
         """Compute the metric.
 
         Currently, there are 3 implementations of this method: NumPy and
-        PyTorch and OneFlow. Which implementation to use is determined by the type of the
-        calling parameters. e.g. `numpy.ndarray` or `torch.Tensor`, `oneflow.Tensor`.
+        PyTorch and OneFlow. Which implementation to use is determined by the
+        type of the calling parameters. e.g. `numpy.ndarray` or
+        `torch.Tensor`, `oneflow.Tensor`.
         This method would be invoked in `BaseMetric.compute` after distributed
         synchronization.
         Args:
-            results (List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS, ONEFLOW_IMPL_HINTS]]): A list
-                of tuples that consisting the prediction and label. This list
-                has already been synced across all ranks.
+            results (List[Union[NUMPY_IMPL_HINTS, TORCH_IMPL_HINTS,
+            ONEFLOW_IMPL_HINTS]]): A list of tuples that consisting the
+            prediction and label. This list has already been synced across
+            all ranks.
         Returns:
             Dict[str, float]: The computed metric.
         """

--- a/mmeval/metrics/single_label.py
+++ b/mmeval/metrics/single_label.py
@@ -80,7 +80,7 @@ def _precision_recall_f1_support(pred_positive: Union[np.ndarray,
         pred_sum = pred_positive.sum(0)
         gt_sum = gt_positive.sum(0)
 
-    # in case torch/oneflow is not supported
+    # in case torch / oneflow is not supported
     if torch and isinstance(pred_sum, torch.Tensor):
         # use torch with torch.Tensor
         precision = tp_sum / torch.clamp(pred_sum, min=1).float() * 100

--- a/mmeval/metrics/single_label.py
+++ b/mmeval/metrics/single_label.py
@@ -91,8 +91,12 @@ def _precision_recall_f1_support(pred_positive: Union[np.ndarray,
         # use oneflow with oneflow.Tensor
         precision = tp_sum / flow.clamp(pred_sum, min=1).float() * 100
         recall = tp_sum / flow.clamp(gt_sum, min=1).float() * 100
+        if (hasattr(flow, 'finfo')):
+            min = min = flow.finfo(flow.float32).eps
+        else:
+            min = 1.1920928955078125e-07
         f1_score = 2 * precision * recall / flow.clamp(
-            precision + recall, min=flow.finfo(flow.float32).eps)
+            precision + recall, min=min)
     else:
         # use numpy with numpy.ndarray
         precision = tp_sum / np.clip(pred_sum, 1, np.inf) * 100

--- a/mmeval/metrics/single_label.py
+++ b/mmeval/metrics/single_label.py
@@ -91,12 +91,8 @@ def _precision_recall_f1_support(pred_positive: Union[np.ndarray,
         # use oneflow with oneflow.Tensor
         precision = tp_sum / flow.clamp(pred_sum, min=1).float() * 100
         recall = tp_sum / flow.clamp(gt_sum, min=1).float() * 100
-        if (hasattr(flow, 'finfo')):
-            min = min = flow.finfo(flow.float32).eps
-        else:
-            min = 1.1920928955078125e-07
         f1_score = 2 * precision * recall / flow.clamp(
-            precision + recall, min=min)
+            precision + recall, min=flow.finfo(flow.float32).eps)
     else:
         # use numpy with numpy.ndarray
         precision = tp_sum / np.clip(pred_sum, 1, np.inf) * 100

--- a/tests/test_metrics/test_accuracy.py
+++ b/tests/test_metrics/test_accuracy.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from distutils.version import LooseVersion
 
 from mmeval.core.base_metric import BaseMetric
 from mmeval.metrics import Accuracy
@@ -46,8 +47,9 @@ def test_metric_interface_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_interface_oneflow():
     accuracy = Accuracy()
     results = accuracy(flow.Tensor([1, 2, 3]), flow.Tensor([3, 2, 1]))
@@ -143,8 +145,9 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
         np.testing.assert_allclose(np_acc_results[key], torch_acc_results[key])
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_accuracy.py
+++ b/tests/test_metrics/test_accuracy.py
@@ -12,6 +12,7 @@ from mmeval.utils import try_import
 torch = try_import('torch')
 tf = try_import('tensorflow')
 paddle = try_import('paddle')
+flow = try_import('oneflow')
 
 
 @pytest.mark.parametrize(
@@ -42,6 +43,15 @@ def test_metric_interface_torch():
     assert isinstance(results, dict)
     results = accuracy(
         torch.Tensor([[0.1, 0.9], [0.5, 0.5]]), torch.Tensor([0, 1]))
+    assert isinstance(results, dict)
+
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+def test_metric_interface_oneflow():
+    accuracy = Accuracy()
+    results = accuracy(flow.Tensor([1, 2, 3]), flow.Tensor([3, 2, 1]))
+    assert isinstance(results, dict)
+    results = accuracy(
+        flow.Tensor([[0.1, 0.9], [0.5, 0.5]]), flow.Tensor([0, 1]))
     assert isinstance(results, dict)
 
 
@@ -129,6 +139,35 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
 
     for key in np_acc_results:
         np.testing.assert_allclose(np_acc_results[key], torch_acc_results[key])
+
+
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.parametrize(
+    argnames=('metric_kwargs', 'classes_num', 'length'),
+    argvalues=[
+        ({}, 100, 100),
+        ({'topk': 1, 'thrs': 0.1}, 1000, 100),
+        ({'topk': (1, 2, 3), 'thrs': (0.1, 0.2)}, 1000, 10000),
+        ({'topk': (1, 2, 3), 'thrs': (0.1, None)}, 999, 10002)
+    ]
+)
+def test_metamorphic_numpy_oneflow(metric_kwargs, classes_num, length):
+    """Metamorphic testing for NumPy and OneFlow implementation."""
+    accuracy = Accuracy(**metric_kwargs)
+
+    predictions = np.random.rand(length, classes_num)
+    labels = np.random.randint(0, classes_num, length)
+
+    np_acc_results = accuracy(predictions, labels)
+
+    predictions = flow.from_numpy(predictions)
+    labels = flow.from_numpy(labels)
+    oneflow_acc_results = accuracy(predictions, labels)
+
+    assert np_acc_results.keys() == oneflow_acc_results.keys()
+
+    for key in np_acc_results:
+        np.testing.assert_allclose(np_acc_results[key], oneflow_acc_results[key])
 
 
 @pytest.mark.skipif(tf is None, reason='TensorFlow is not available!')

--- a/tests/test_metrics/test_accuracy.py
+++ b/tests/test_metrics/test_accuracy.py
@@ -45,6 +45,7 @@ def test_metric_interface_torch():
         torch.Tensor([[0.1, 0.9], [0.5, 0.5]]), torch.Tensor([0, 1]))
     assert isinstance(results, dict)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_interface_oneflow():
     accuracy = Accuracy()
@@ -162,12 +163,12 @@ def test_metamorphic_numpy_oneflow(metric_kwargs, classes_num, length):
 
     predictions = flow.from_numpy(predictions)
     labels = flow.from_numpy(labels)
-    oneflow_acc_results = accuracy(predictions, labels)
+    flow_acc_results = accuracy(predictions, labels)
 
-    assert np_acc_results.keys() == oneflow_acc_results.keys()
+    assert np_acc_results.keys() == flow_acc_results.keys()
 
     for key in np_acc_results:
-        np.testing.assert_allclose(np_acc_results[key], oneflow_acc_results[key])
+        np.testing.assert_allclose(np_acc_results[key], flow_acc_results[key])
 
 
 @pytest.mark.skipif(tf is None, reason='TensorFlow is not available!')

--- a/tests/test_metrics/test_accuracy.py
+++ b/tests/test_metrics/test_accuracy.py
@@ -46,7 +46,8 @@ def test_metric_interface_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_interface_oneflow():
     accuracy = Accuracy()
     results = accuracy(flow.Tensor([1, 2, 3]), flow.Tensor([3, 2, 1]))
@@ -142,7 +143,8 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
         np.testing.assert_allclose(np_acc_results[key], torch_acc_results[key])
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_average_precision.py
+++ b/tests/test_metrics/test_average_precision.py
@@ -65,6 +65,7 @@ def test_metric_input_torch(preds, labels):
     results = average_precision(preds, labels)
     assert isinstance(results, dict)
 
+
 @pytest.mark.parametrize('preds', [
     flow.tensor([[0.1, 0.9], [0.5, 0.6]]),  # scores in a ndarray
     [flow.tensor([0.1, 0.9]), flow.tensor([0.5, 0.6])],  # scores in Sequence

--- a/tests/test_metrics/test_average_precision.py
+++ b/tests/test_metrics/test_average_precision.py
@@ -7,11 +7,10 @@ import pytest
 
 from mmeval.core.base_metric import BaseMetric
 from mmeval.metrics import AveragePrecision
+from mmeval.utils import try_import
 
-try:
-    import torch
-except ImportError:
-    torch = None
+torch = try_import('torch')
+flow = try_import('oneflow')
 
 
 def test_metric_init_assertion():
@@ -62,6 +61,23 @@ def test_metric_input_builtin(preds, labels):
 @pytest.mark.skipif(torch is None, reason='PyTorch is not available!')
 def test_metric_input_torch(preds, labels):
     """Test torch inputs."""
+    average_precision = AveragePrecision()
+    results = average_precision(preds, labels)
+    assert isinstance(results, dict)
+
+@pytest.mark.parametrize('preds', [
+    flow.tensor([[0.1, 0.9], [0.5, 0.6]]),  # scores in a ndarray
+    [flow.tensor([0.1, 0.9]), flow.tensor([0.5, 0.6])],  # scores in Sequence
+])
+@pytest.mark.parametrize('labels', [
+    flow.tensor([[1, 0], [0, 1]]),  # one-hot encodings labels in a ndarray
+    # one-hot encodings labels in Sequence
+    [flow.tensor([1, 0]), flow.tensor([0, 1])],
+    [flow.tensor([0]), flow.tensor([1])],  # label-format labels in Sequence
+])
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+def test_metric_input_flow(preds, labels):
+    """Test oneflow inputs."""
     average_precision = AveragePrecision()
     results = average_precision(preds, labels)
     assert isinstance(results, dict)
@@ -146,3 +162,32 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
         # numpy use float64 however torch use float32
         np.testing.assert_allclose(
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
+
+
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.parametrize(
+    argnames=('metric_kwargs', 'classes_num', 'length'),
+    argvalues=[
+        ({}, 100, 100),
+        ({}, 1000, 10000),
+        ({'average': None}, 999, 10002)
+    ]
+)
+def test_metamorphic_numpy_oneflow(metric_kwargs, classes_num, length):
+    """Metamorphic testing for NumPy and OneFlow implementation."""
+    average_precision = AveragePrecision(**metric_kwargs)
+
+    preds = np.random.rand(length, classes_num)
+    labels = np.random.randint(0, classes_num, length)
+
+    np_acc_results = average_precision(preds, labels)
+
+    preds = flow.from_numpy(preds)
+    labels = flow.from_numpy(labels)
+    oneflow_acc_results = average_precision(preds, labels)
+
+    assert np_acc_results.keys() == oneflow_acc_results.keys()
+    for key in np_acc_results:
+        # numpy use float64 however oneflow use float32
+        np.testing.assert_allclose(
+            np_acc_results[key], oneflow_acc_results[key], rtol=1e-5)

--- a/tests/test_metrics/test_average_precision.py
+++ b/tests/test_metrics/test_average_precision.py
@@ -67,18 +67,26 @@ def test_metric_input_torch(preds, labels):
 
 
 @pytest.mark.parametrize('preds', [
-    flow.tensor([[0.1, 0.9], [0.5, 0.6]]),  # scores in a ndarray
-    [flow.tensor([0.1, 0.9]), flow.tensor([0.5, 0.6])],  # scores in Sequence
+    np.array([[0.1, 0.9], [0.5, 0.6]]),  # scores in a ndarray
+    [[0.1, 0.9], [0.5, 0.6]],  # scores in Sequence
 ])
 @pytest.mark.parametrize('labels', [
-    flow.tensor([[1, 0], [0, 1]]),  # one-hot encodings labels in a ndarray
+    np.array([[1, 0], [0, 1]]),  # one-hot encodings labels in a ndarray
     # one-hot encodings labels in Sequence
-    [flow.tensor([1, 0]), flow.tensor([0, 1])],
-    [flow.tensor([0]), flow.tensor([1])],  # label-format labels in Sequence
+    [[1, 0], [0, 1]],
+    [[0], [1]],  # label-format labels in Sequence
 ])
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_input_flow(preds, labels):
     """Test oneflow inputs."""
+    if isinstance(preds, np.ndarray):
+        preds = flow.tensor(preds)
+    else:
+        preds = list(flow.tensor(pred) for pred in preds)
+    if isinstance(labels, np.ndarray):
+        labels = flow.tensor(labels)
+    else:
+        labels = list(flow.tensor(label) for label in labels)
     average_precision = AveragePrecision()
     results = average_precision(preds, labels)
     assert isinstance(results, dict)

--- a/tests/test_metrics/test_end_point_error.py
+++ b/tests/test_metrics/test_end_point_error.py
@@ -31,6 +31,7 @@ def test_metric_interface_torch():
     results = epe(torch.randn(10, 10, 2), torch.randn(10, 10, 2))
     assert isinstance(results, dict)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_interface_oneflow():
     epe = EndPointError()
@@ -38,6 +39,7 @@ def test_metric_interface_oneflow():
 
     results = epe(flow.randn(10, 10, 2), flow.randn(10, 10, 2))
     assert isinstance(results, dict)
+
 
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels', 'valid_masks'],
@@ -76,6 +78,7 @@ def test_metamorphic_numpy_pytorch():
     for key in np_results:
         np.testing.assert_allclose(
             np_results[key], torch_results[key], rtol=1e-06)
+
 
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metamorphic_numpy_oneflow():

--- a/tests/test_metrics/test_end_point_error.py
+++ b/tests/test_metrics/test_end_point_error.py
@@ -10,6 +10,7 @@ from mmeval.metrics import EndPointError
 from mmeval.utils import try_import
 
 torch = try_import('torch')
+flow = try_import('oneflow')
 
 
 def test_metric_interface_numpy():
@@ -30,6 +31,13 @@ def test_metric_interface_torch():
     results = epe(torch.randn(10, 10, 2), torch.randn(10, 10, 2))
     assert isinstance(results, dict)
 
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+def test_metric_interface_oneflow():
+    epe = EndPointError()
+    assert isinstance(epe, BaseMetric)
+
+    results = epe(flow.randn(10, 10, 2), flow.randn(10, 10, 2))
+    assert isinstance(results, dict)
 
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels', 'valid_masks'],
@@ -68,6 +76,25 @@ def test_metamorphic_numpy_pytorch():
     for key in np_results:
         np.testing.assert_allclose(
             np_results[key], torch_results[key], rtol=1e-06)
+
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+def test_metamorphic_numpy_oneflow():
+    """Metamorphic testing for NumPy and OneFlow implementation."""
+
+    epe = EndPointError()
+    predictions = np.random.normal(size=(10, 10, 2))
+    labels = np.random.normal(size=(10, 10, 2))
+    np_results = epe(predictions, labels)
+
+    predictions = flow.from_numpy(predictions)
+    labels = flow.from_numpy(labels)
+    oneflow_results = epe(predictions, labels)
+
+    assert np_results.keys() == oneflow_results.keys()
+
+    for key in np_results:
+        np.testing.assert_allclose(
+            np_results[key], oneflow_results[key], rtol=1e-06)
 
 
 if __name__ == '__main__':

--- a/tests/test_metrics/test_f_metric.py
+++ b/tests/test_metrics/test_f_metric.py
@@ -58,7 +58,9 @@ def test_macro_metric_torch(predictions, labels):
     assertions.assertAlmostEqual(results['macro_f1'], 0.25)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(
+    flow is None or flow.__version__ < '0.8.1',
+    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
@@ -148,7 +150,9 @@ def test_micro_metric_torch(predictions, labels):
     assertions.assertAlmostEqual(results['micro_f1'], 0.285, delta=0.001)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(
+    flow is None or flow.__version__ < '0.8.1',
+    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
@@ -227,7 +231,9 @@ def test_mode_torch():
     assertions.assertAlmostEqual(results['macro_f1'], 0.39, delta=0.01)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(
+    flow is None or flow.__version__ < '0.8.1',
+    reason='OneFlow > 0.8.0 is required!')
 def test_mode_oneflow():
     predictions = [flow.LongTensor([0, 1, 0, 1, 2])]
     labels = [flow.LongTensor([0, 1, 2, 2, 0])]

--- a/tests/test_metrics/test_f_metric.py
+++ b/tests/test_metrics/test_f_metric.py
@@ -57,6 +57,7 @@ def test_macro_metric_torch(predictions, labels):
     assert isinstance(results, dict)
     assertions.assertAlmostEqual(results['macro_f1'], 0.25)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
@@ -147,12 +148,13 @@ def test_micro_metric_torch(predictions, labels):
     assert isinstance(results, dict)
     assertions.assertAlmostEqual(results['micro_f1'], 0.285, delta=0.001)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
         ([flow.LongTensor([0, 1, 0, 1,
-                            2])], [flow.LongTensor([0, 1, 2, 2, 0])]),
+                           2])], [flow.LongTensor([0, 1, 2, 2, 0])]),
         ([flow.LongTensor([0, 1, 0]),
           flow.LongTensor([2, 2])],
          [flow.LongTensor([0, 1, 2]),
@@ -227,6 +229,7 @@ def test_mode_torch():
     assertions.assertAlmostEqual(results['micro_f1'], 0.4, delta=0.01)
     assertions.assertAlmostEqual(results['macro_f1'], 0.39, delta=0.01)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_mode_oneflow():
     predictions = [flow.LongTensor([0, 1, 0, 1, 2])]
@@ -239,6 +242,7 @@ def test_mode_oneflow():
     assert isinstance(results, dict)
     assertions.assertAlmostEqual(results['micro_f1'], 0.4, delta=0.01)
     assertions.assertAlmostEqual(results['macro_f1'], 0.39, delta=0.01)
+
 
 def test_mode_np():
     predictions = [np.array([0, 1, 0, 1, 2])]

--- a/tests/test_metrics/test_f_metric.py
+++ b/tests/test_metrics/test_f_metric.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 import unittest
+from distutils.version import LooseVersion
 
 from mmeval.metrics import F1Metric
 from mmeval.utils import try_import
@@ -59,7 +60,7 @@ def test_macro_metric_torch(predictions, labels):
 
 
 @pytest.mark.skipif(
-    flow is None or flow.__version__ < '0.8.1',
+    flow is None or LooseVersion(flow.__version__) < '0.8.1',
     reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
@@ -151,8 +152,8 @@ def test_micro_metric_torch(predictions, labels):
 
 
 @pytest.mark.skipif(
-    flow is None or flow.__version__ < '0.8.1',
-    reason='OneFlow > 0.8.0 is required!')
+    flow is None or LooseVersion(flow.__version__) < '0.8.1',
+    reason='OneFlow >= 0.8.1 is required!')
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
@@ -232,8 +233,8 @@ def test_mode_torch():
 
 
 @pytest.mark.skipif(
-    flow is None or flow.__version__ < '0.8.1',
-    reason='OneFlow > 0.8.0 is required!')
+    flow is None or LooseVersion(flow.__version__) < '0.8.1',
+    reason='OneFlow >= 0.8.1 is required!')
 def test_mode_oneflow():
     predictions = [flow.LongTensor([0, 1, 0, 1, 2])]
     labels = [flow.LongTensor([0, 1, 2, 2, 0])]

--- a/tests/test_metrics/test_f_metric.py
+++ b/tests/test_metrics/test_f_metric.py
@@ -63,15 +63,14 @@ def test_macro_metric_torch(predictions, labels):
     argnames=['predictions', 'labels'],
     argvalues=[
         ([[0, 1, 2]], [[0, 1, 4]]),
-        ([[0, 1], [2]],
-         [[0, 1], [4]]),
+        ([[0, 1], [2]], [[0, 1], [4]]),
     ],
 )
 def test_macro_metric_oneflow(predictions, labels):
     assertions = unittest.TestCase('__init__')
-    predictions = list(flow.LongTensor(prediction) for prediction in predictions)
+    predictions = list(
+        flow.LongTensor(prediction) for prediction in predictions)
     labels = list(flow.LongTensor(label) for label in labels)
-    print(predictions, labels)
     f1 = F1Metric(num_classes=5, mode='macro')
     results = f1(predictions, labels)
     assert isinstance(results, dict)
@@ -154,12 +153,12 @@ def test_micro_metric_torch(predictions, labels):
     argnames=['predictions', 'labels'],
     argvalues=[
         ([[0, 1, 0, 1, 2]], [[0, 1, 2, 2, 0]]),
-        ([[0, 1, 0], [2, 2]],
-         [[0, 1, 2], [0, 1]]),
+        ([[0, 1, 0], [2, 2]], [[0, 1, 2], [0, 1]]),
     ])
 def test_micro_metric_oneflow(predictions, labels):
     assertions = unittest.TestCase('__init__')
-    predictions = list(flow.LongTensor(prediction) for prediction in predictions)
+    predictions = list(
+        flow.LongTensor(prediction) for prediction in predictions)
     labels = list(flow.LongTensor(label) for label in labels)
     f1 = F1Metric(num_classes=3, mode='micro')
     results = f1(predictions, labels)

--- a/tests/test_metrics/test_f_metric.py
+++ b/tests/test_metrics/test_f_metric.py
@@ -62,16 +62,16 @@ def test_macro_metric_torch(predictions, labels):
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
-        ([flow.LongTensor([0, 1, 2])], [flow.LongTensor([0, 1, 4])]),
-        ([flow.LongTensor([0, 1]),
-          flow.LongTensor([2])],
-         [flow.LongTensor([0, 1]),
-          flow.LongTensor([4])]),
+        ([[0, 1, 2]], [[0, 1, 4]]),
+        ([[0, 1], [2]],
+         [[0, 1], [4]]),
     ],
 )
 def test_macro_metric_oneflow(predictions, labels):
     assertions = unittest.TestCase('__init__')
-
+    predictions = list(flow.LongTensor(prediction) for prediction in predictions)
+    labels = list(flow.LongTensor(label) for label in labels)
+    print(predictions, labels)
     f1 = F1Metric(num_classes=5, mode='macro')
     results = f1(predictions, labels)
     assert isinstance(results, dict)
@@ -153,16 +153,14 @@ def test_micro_metric_torch(predictions, labels):
 @pytest.mark.parametrize(
     argnames=['predictions', 'labels'],
     argvalues=[
-        ([flow.LongTensor([0, 1, 0, 1,
-                           2])], [flow.LongTensor([0, 1, 2, 2, 0])]),
-        ([flow.LongTensor([0, 1, 0]),
-          flow.LongTensor([2, 2])],
-         [flow.LongTensor([0, 1, 2]),
-          flow.LongTensor([0, 1])]),
+        ([[0, 1, 0, 1, 2]], [[0, 1, 2, 2, 0]]),
+        ([[0, 1, 0], [2, 2]],
+         [[0, 1, 2], [0, 1]]),
     ])
 def test_micro_metric_oneflow(predictions, labels):
     assertions = unittest.TestCase('__init__')
-
+    predictions = list(flow.LongTensor(prediction) for prediction in predictions)
+    labels = list(flow.LongTensor(label) for label in labels)
     f1 = F1Metric(num_classes=3, mode='micro')
     results = f1(predictions, labels)
     assert isinstance(results, dict)

--- a/tests/test_metrics/test_mean_iou.py
+++ b/tests/test_metrics/test_mean_iou.py
@@ -38,7 +38,8 @@ def test_metric_interface_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_interface_oneflow():
     miou = MeanIoU(num_classes=4)
     assert isinstance(miou, BaseMetric)
@@ -143,7 +144,8 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, length):
             np_results[key], torch_results[key], rtol=1e-06)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_mean_iou.py
+++ b/tests/test_metrics/test_mean_iou.py
@@ -12,6 +12,7 @@ from mmeval.utils import try_import
 torch = try_import('torch')
 paddle = try_import('paddle')
 tf = try_import('tensorflow')
+flow = try_import('oneflow')
 
 
 def test_metric_interface_numpy():
@@ -36,6 +37,16 @@ def test_metric_interface_torch():
     )
     assert isinstance(results, dict)
 
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+def test_metric_interface_oneflow():
+    miou = MeanIoU(num_classes=4)
+    assert isinstance(miou, BaseMetric)
+
+    results = miou(
+        flow.randint(0, 4, size=(2, 10, 10)),
+        flow.randint(0, 4, size=(2, 10, 10))
+    )
+    assert isinstance(results, dict)
 
 @pytest.mark.skipif(paddle is None, reason='Paddle is not available!')
 def test_metric_interface_paddle():
@@ -128,6 +139,35 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, length):
     for key in np_results:
         np.testing.assert_allclose(
             np_results[key], torch_results[key], rtol=1e-06)
+
+@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.parametrize(
+    argnames=('metric_kwargs', 'length'),
+    argvalues=[
+        ({'num_classes': 10}, 100),
+        ({'num_classes': 100}, 1000),
+        ({'num_classes': 222}, 500)
+    ]
+)
+def test_metamorphic_numpy_oneflow(metric_kwargs, length):
+    """Metamorphic testing for NumPy and OneFlow implementation."""
+    miou = MeanIoU(**metric_kwargs)
+    num_classes = metric_kwargs.get('num_classes')
+
+    predictions = np.random.randint(0, num_classes, size=(length, 224, 224))
+    labels = np.random.randint(0, num_classes, size=(length, 224, 224))
+
+    np_results = miou(predictions, labels)
+
+    predictions = flow.from_numpy(predictions)
+    labels = flow.from_numpy(labels)
+    oneflow_results = miou(predictions, labels)
+
+    assert np_results.keys() == oneflow_results.keys()
+
+    for key in np_results:
+        np.testing.assert_allclose(
+            np_results[key], oneflow_results[key], rtol=1e-06)
 
 
 @pytest.mark.skipif(paddle is None, reason='Paddle is not available!')

--- a/tests/test_metrics/test_mean_iou.py
+++ b/tests/test_metrics/test_mean_iou.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from distutils.version import LooseVersion
 
 from mmeval.core.base_metric import BaseMetric
 from mmeval.metrics import MeanIoU
@@ -38,8 +39,9 @@ def test_metric_interface_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_interface_oneflow():
     miou = MeanIoU(num_classes=4)
     assert isinstance(miou, BaseMetric)
@@ -144,8 +146,9 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, length):
             np_results[key], torch_results[key], rtol=1e-06)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_mean_iou.py
+++ b/tests/test_metrics/test_mean_iou.py
@@ -37,6 +37,7 @@ def test_metric_interface_torch():
     )
     assert isinstance(results, dict)
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_interface_oneflow():
     miou = MeanIoU(num_classes=4)
@@ -47,6 +48,7 @@ def test_metric_interface_oneflow():
         flow.randint(0, 4, size=(2, 10, 10))
     )
     assert isinstance(results, dict)
+
 
 @pytest.mark.skipif(paddle is None, reason='Paddle is not available!')
 def test_metric_interface_paddle():
@@ -139,6 +141,7 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, length):
     for key in np_results:
         np.testing.assert_allclose(
             np_results[key], torch_results[key], rtol=1e-06)
+
 
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 @pytest.mark.parametrize(

--- a/tests/test_metrics/test_multi_label.py
+++ b/tests/test_metrics/test_multi_label.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from distutils.version import LooseVersion
 
 from mmeval.core.base_metric import BaseMetric
 from mmeval.metrics import MultiLabelMetric
@@ -113,8 +114,9 @@ def test_metric_interface_torch_topk(metric_kwargs, preds, labels):
     [[1, 0, 0], [0, 1, 0]],
     [[0], [1]],  # label-format in Sequence
 ])
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_interface_oneflow_topk(metric_kwargs, preds, labels):
     """Test scores inputs with topk in OneFlow."""
     if isinstance(preds, np.ndarray):
@@ -193,8 +195,9 @@ def test_metric_interface_torch(metric_kwargs, preds, labels):
     [[1, 0, 0], [0, 1, 0]],
     [[0], [1]],  # label-format in Sequence
 ])
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_interface_oneflow(metric_kwargs, preds, labels):
     """Test all kinds of inputs in OneFlow."""
     if isinstance(preds, np.ndarray):
@@ -287,8 +290,9 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_multi_label.py
+++ b/tests/test_metrics/test_multi_label.py
@@ -178,23 +178,31 @@ def test_metric_interface_torch(metric_kwargs, preds, labels):
 
 @pytest.mark.parametrize('metric_kwargs', [{'num_classes': 3}])
 @pytest.mark.parametrize('preds', [
-    flow.Tensor([[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]]),  # scores in a Tensor
+    np.array([[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]]),  # scores in a Tensor
     # scores in Sequence
-    [flow.Tensor([0.1, 0.9, 0.8]), flow.Tensor([0.5, 0.6, 0.8])],
-    flow.Tensor([[0, 1, 0], [1, 1, 0]]),  # one-hot encodings in a Tensor
+    [[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]],
+    np.array([[0, 1, 0], [1, 1, 0]]),  # one-hot encodings in a Tensor
     # one-hot encodings in Sequence
-    [flow.Tensor([0, 1, 0]), flow.Tensor([1, 1, 0])],
-    [flow.Tensor([1]), flow.Tensor([0, 1])],  # label-format in Sequence
+    [[0, 1, 0], [1, 1, 0]],
+    [[1], [0, 1]],  # label-format in Sequence
 ])
 @pytest.mark.parametrize('labels', [
-    flow.Tensor([[1, 0, 0], [0, 1, 0]]),  # one-hot encodings in a Tensor
+    np.array([[1, 0, 0], [0, 1, 0]]),  # one-hot encodings in a Tensor
     # one-hot encodings in Sequence
-    [flow.Tensor([1, 0, 0]), flow.Tensor([0, 1, 0])],
-    [flow.Tensor([0]), flow.Tensor([1])],  # label-format in Sequence
+    [[1, 0, 0], [0, 1, 0]],
+    [[0], [1]],  # label-format in Sequence
 ])
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_interface_oneflow(metric_kwargs, preds, labels):
     """Test all kinds of inputs in OneFlow."""
+    if isinstance(preds, np.ndarray):
+        preds = flow.tensor(preds)
+    else:
+        preds = list(flow.tensor(pred) for pred in preds)
+    if isinstance(labels, np.ndarray):
+        labels = flow.tensor(labels)
+    else:
+        labels = list(flow.tensor(label) for label in labels)
     multi_label_metric = MultiLabelMetric(**metric_kwargs)
     results = multi_label_metric(preds, labels)
     assert isinstance(results, dict)

--- a/tests/test_metrics/test_multi_label.py
+++ b/tests/test_metrics/test_multi_label.py
@@ -103,19 +103,27 @@ def test_metric_interface_torch_topk(metric_kwargs, preds, labels):
 
 @pytest.mark.parametrize('metric_kwargs', [{'num_classes': 3, 'topk': 1}])
 @pytest.mark.parametrize('preds', [
-    flow.Tensor([[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]]),  # scores in a Tensor
+    np.array([[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]]),  # scores in a Tensor
     # scores in Sequence
-    [flow.Tensor([0.1, 0.9, 0.8]), flow.Tensor([0.5, 0.6, 0.8])],
+    [[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]],
 ])
 @pytest.mark.parametrize('labels', [
-    flow.Tensor([[1, 0, 0], [0, 1, 0]]),  # one-hot encodings in a Tensor
+    np.array([[1, 0, 0], [0, 1, 0]]),  # one-hot encodings in a Tensor
     # one-hot encodings in Sequence
-    [flow.Tensor([1, 0, 0]), flow.Tensor([0, 1, 0])],
-    [flow.Tensor([0]), flow.Tensor([1])],  # label-format in Sequence
+    [[1, 0, 0], [0, 1, 0]],
+    [[0], [1]],  # label-format in Sequence
 ])
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_interface_oneflow_topk(metric_kwargs, preds, labels):
     """Test scores inputs with topk in OneFlow."""
+    if isinstance(preds, np.ndarray):
+        preds = flow.tensor(preds)
+    else:
+        preds = list(flow.tensor(pred) for pred in preds)
+    if isinstance(labels, np.ndarray):
+        labels = flow.tensor(labels)
+    else:
+        labels = list(flow.tensor(label) for label in labels)
     multi_label_metric = MultiLabelMetric(**metric_kwargs)
     results = multi_label_metric(preds, labels)
     assert isinstance(results, dict)

--- a/tests/test_metrics/test_multi_label.py
+++ b/tests/test_metrics/test_multi_label.py
@@ -100,6 +100,7 @@ def test_metric_interface_torch_topk(metric_kwargs, preds, labels):
     results = multi_label_metric(preds, labels)
     assert isinstance(results, dict)
 
+
 @pytest.mark.parametrize('metric_kwargs', [{'num_classes': 3, 'topk': 1}])
 @pytest.mark.parametrize('preds', [
     flow.Tensor([[0.1, 0.9, 0.8], [0.5, 0.6, 0.8]]),  # scores in a Tensor
@@ -266,6 +267,7 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
         # precision is different between numpy and torch
         np.testing.assert_allclose(
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
+
 
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 @pytest.mark.parametrize(

--- a/tests/test_metrics/test_multi_label.py
+++ b/tests/test_metrics/test_multi_label.py
@@ -113,7 +113,8 @@ def test_metric_interface_torch_topk(metric_kwargs, preds, labels):
     [[1, 0, 0], [0, 1, 0]],
     [[0], [1]],  # label-format in Sequence
 ])
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_interface_oneflow_topk(metric_kwargs, preds, labels):
     """Test scores inputs with topk in OneFlow."""
     if isinstance(preds, np.ndarray):
@@ -192,7 +193,8 @@ def test_metric_interface_torch(metric_kwargs, preds, labels):
     [[1, 0, 0], [0, 1, 0]],
     [[0], [1]],  # label-format in Sequence
 ])
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_interface_oneflow(metric_kwargs, preds, labels):
     """Test all kinds of inputs in OneFlow."""
     if isinstance(preds, np.ndarray):
@@ -285,7 +287,8 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_single_label_metric.py
+++ b/tests/test_metrics/test_single_label_metric.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from distutils.version import LooseVersion
 
 from mmeval.core.base_metric import BaseMetric
 from mmeval.metrics import SingleLabelMetric
@@ -50,8 +51,9 @@ def test_metric_torch_assertion():
             torch.Tensor([[0.1, 0.9, 0], [0.5, 0.5, 0]]), torch.Tensor([0, 1]))
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_oneflow_assertion():
     single_label_metric = SingleLabelMetric()
     with pytest.raises(AssertionError, match='Please specify `num_classes`'):
@@ -110,8 +112,9 @@ def test_metric_input_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 def test_metric_input_oneflow():
     # test predictions with labels
     single_label_metric = SingleLabelMetric()
@@ -206,8 +209,9 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
 
 
-@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
-                    reason='OneFlow > 0.8.0 is required!')
+@pytest.mark.skipif(flow is None or
+                    LooseVersion(flow.__version__) < '0.8.1',
+                    reason='OneFlow >= 0.8.1 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[

--- a/tests/test_metrics/test_single_label_metric.py
+++ b/tests/test_metrics/test_single_label_metric.py
@@ -49,6 +49,7 @@ def test_metric_torch_assertion():
         single_label_metric(
             torch.Tensor([[0.1, 0.9, 0], [0.5, 0.5, 0]]), torch.Tensor([0, 1]))
 
+
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_oneflow_assertion():
     single_label_metric = SingleLabelMetric()
@@ -61,6 +62,7 @@ def test_metric_oneflow_assertion():
                        match='Number of classes does not match'):
         single_label_metric(
             flow.Tensor([[0.1, 0.9, 0], [0.5, 0.5, 0]]), flow.Tensor([0, 1]))
+
 
 @pytest.mark.parametrize(
     argnames='metric_kwargs',
@@ -105,6 +107,7 @@ def test_metric_input_torch():
     results = single_label_metric(
         torch.Tensor([1, 2, 3]), torch.Tensor([3, 2, 1]))
     assert isinstance(results, dict)
+
 
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 def test_metric_input_oneflow():
@@ -199,6 +202,7 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
     for key in np_acc_results:
         np.testing.assert_allclose(
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
+
 
 @pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
 @pytest.mark.parametrize(

--- a/tests/test_metrics/test_single_label_metric.py
+++ b/tests/test_metrics/test_single_label_metric.py
@@ -50,7 +50,8 @@ def test_metric_torch_assertion():
             torch.Tensor([[0.1, 0.9, 0], [0.5, 0.5, 0]]), torch.Tensor([0, 1]))
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_oneflow_assertion():
     single_label_metric = SingleLabelMetric()
     with pytest.raises(AssertionError, match='Please specify `num_classes`'):
@@ -109,7 +110,8 @@ def test_metric_input_torch():
     assert isinstance(results, dict)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 def test_metric_input_oneflow():
     # test predictions with labels
     single_label_metric = SingleLabelMetric()
@@ -204,7 +206,8 @@ def test_metamorphic_numpy_pytorch(metric_kwargs, classes_num, length):
             np_acc_results[key], torch_acc_results[key], rtol=1e-5)
 
 
-@pytest.mark.skipif(flow is None, reason='OneFlow is not available!')
+@pytest.mark.skipif(flow is None or flow.__version__ < '0.8.1',
+                    reason='OneFlow > 0.8.0 is required!')
 @pytest.mark.parametrize(
     argnames=('metric_kwargs', 'classes_num', 'length'),
     argvalues=[


### PR DESCRIPTION
## Motivation

add oneflow backend for mmeval.

## Modification
add the following metrics and unittests in oneflow:
- accuracy 
- end_point_error 
- f_metric 
- mean_iou 
- multi_label 
- single_label
