### PR TITLE
[CodeCamp #3] Add dota metric

### DIFF
--- a/mmeval/metrics/__init__.py
+++ b/mmeval/metrics/__init__.py
@@ -3,6 +3,7 @@
 from .accuracy import Accuracy
 from .ava_map import AVAMeanAP
 from .coco_detection import COCODetectionMetric
+from .dota_metric import DOTAMetric
 from .end_point_error import EndPointError
 from .f_metric import F1Metric
 from .hmean_iou import HmeanIoU
@@ -24,5 +25,5 @@ __all__ = [
     'F1Metric', 'HmeanIoU', 'SingleLabelMetric', 'COCODetectionMetric',
     'PCKAccuracy', 'MpiiPCKAccuracy', 'JhmdbPCKAccuracy', 'ProposalRecall',
     'PSNR', 'MAE', 'MSE', 'SSIM', 'SNR', 'MultiLabelMetric',
-    'AveragePrecision', 'AVAMeanAP'
+    'AveragePrecision', 'AVAMeanAP', 'DOTAMetric'
 ]

--- a/mmeval/metrics/dota_metric.py
+++ b/mmeval/metrics/dota_metric.py
@@ -95,6 +95,33 @@ class DOTAMetric(BaseMetric):
         classwise (bool): Whether to return the computed results of each
             class. Defaults to False.
         **kwargs: Keyword parameters passed to :class:`BaseMetric`.
+    Examples:
+        >>> import numpy as np
+        >>> from mmeval import DOTAMetric
+        >>> num_classes = 15
+        >>> dota_metric = DOTAMetric(num_classes=15)
+        >>>
+        >>> def _gen_bboxes(num_bboxes, img_w=256, img_h=256):
+        ...     # random generate bounding boxes in 'xywha' formart.
+        ...     x = np.random.rand(num_bboxes, ) * img_w
+        ...     y = np.random.rand(num_bboxes, ) * img_h
+        ...     w = np.random.rand(num_bboxes, ) * (img_w - x)
+        ...     h = np.random.rand(num_bboxes, ) * (img_h - y)
+        ...     a = np.random.rand(num_bboxes, ) * np.pi / 2
+        ...     return np.stack([x, y, w, h, a], axis=1)
+        >>> prediction = {
+        ...     'bboxes': _gen_bboxes(10),
+        ...     'scores': np.random.rand(10, ),
+        ...     'labels': np.random.randint(0, num_classes, size=(10, ))
+        ... }
+        >>> groundtruth = {
+        ...     'bboxes': _gen_bboxes(10),
+        ...     'labels': np.random.randint(0, num_classes, size=(10, )),
+        ...     'bboxes_ignore': _gen_bboxes(5),
+        ...     'labels_ignore': np.random.randint(0, num_classes, size=(5, ))
+        ... }
+        >>> dota_metric(predictions=[prediction, ], groundtruths=[groundtruth, ])  # doctest: +ELLIPSIS  # noqa: E501
+        {'mAP@0.5': ..., 'mAP': ...}
     """
 
     def __init__(self,

--- a/mmeval/metrics/dota_metric.py
+++ b/mmeval/metrics/dota_metric.py
@@ -12,6 +12,18 @@ from .utils.bbox_iou_rotated import (bbox_iou_rotated,
 def filter_by_bboxes_area_rotated(bboxes: np.ndarray,
                                   min_area: Optional[float],
                                   max_area: Optional[float]):
+    """Filter the rotated bboxes with an area range.
+
+    Args:
+        bboxes (numpy.ndarray): The bboxes with shape (n, 5) in 'xywha' format.
+        min_area (Optional[float]): The minimum area. If None, does not filter
+            the minimum area.
+        max_area (Optional[float]): The maximum area. If None, does not filter
+            the maximum area.
+
+    Returns:
+        numpy.ndarray: A mask of ``bboxes`` identify which bbox are filtered.
+    """
     bboxes_area = calculate_bboxes_area_rotated(bboxes)
     area_mask = np.ones_like(bboxes_area, dtype=bool)
     if min_area is not None:

--- a/mmeval/metrics/dota_metric.py
+++ b/mmeval/metrics/dota_metric.py
@@ -4,13 +4,156 @@ from multiprocessing.pool import Pool
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from mmeval.core.base_metric import BaseMetric
-from .utils.bbox_iou_rotated import bbox_iou_rotated
+from mmeval.utils import is_list_of
+from .utils.bbox_iou_rotated import (bbox_iou_rotated,
+                                     calculate_bboxes_area_rotated)
+
+
+def filter_by_bboxes_area_rotated(bboxes: np.ndarray,
+                                  min_area: Optional[float],
+                                  max_area: Optional[float]):
+    bboxes_area = calculate_bboxes_area_rotated(bboxes)
+    area_mask = np.ones_like(bboxes_area, dtype=bool)
+    if min_area is not None:
+        area_mask &= (bboxes_area >= min_area)
+    if max_area is not None:
+        area_mask &= (bboxes_area < max_area)
+    return area_mask
+
+
+def calculate_average_precision(recalls: np.ndarray,
+                                precisions: np.ndarray,
+                                mode: str = 'area') -> float:
+    """Calculate average precision in the detection task.
+
+    Args:
+        recalls (ndarray): The recalls with shape (num_dets, ).
+        precisions (ndarray): The precisions with shape (num_dets, ).
+        mode (str): The average mode, should be 'area' or '11points'.
+            'area' means calculating the area under precision-recall curve.
+            '11points' means calculating the average precision of recalls at
+            [0, 0.1, ..., 1.0]. Defaults to 'area'.
+
+    Returns:
+        float: Calculated average precision.
+    """
+    assert mode in ['area', '11points']
+    if mode == 'area':
+        mrec = np.hstack((0, recalls, 1))
+        mpre = np.hstack((0, precisions, 0))
+        for i in range(mpre.shape[0] - 1, 0, -1):
+            mpre[i - 1] = np.maximum(mpre[i - 1], mpre[i])
+        ind = np.where(mrec[1:] != mrec[:-1])[0]
+        ap = np.sum((mrec[ind + 1] - mrec[ind]) * mpre[ind + 1])
+    else:
+        ap = 0.0
+        for thr in np.arange(0, 1 + 1e-3, 0.1):
+            precs = precisions[recalls >= thr]
+            prec = precs.max() if precs.size > 0 else 0
+            ap += prec
+        ap /= 11.0
+    return ap
 
 
 class DOTAMetric(BaseMetric):
+    """DOTA evaluation metric.
 
-    def add(self, predictions: Sequence[Dict],
-            groundtruths: Sequence[Dict]) -> None:
+    This metric computes the DOTA mAP (mean Average Precision) with the given
+    IoU thresholds and scale ranges.
+
+    Args:
+        iou_thrs (float ｜ List[float]): IoU thresholds. Defaults to 0.5.
+        scale_ranges (List[tuple], optional): Scale ranges for evaluating
+            mAP. If not specified, all bounding boxes would be included in
+            evaluation. Defaults to None.
+        num_classes (int, optional): The number of classes. If None, it will be
+            obtained from the 'CLASSES' field in ``self.dataset_meta``.
+            Defaults to None.
+        eval_mode (str): 'area' or '11points', 'area' means calculating the
+            area under precision-recall curve, '11points' means calculating
+            the average precision of recalls at [0, 0.1, ..., 1].
+            The PASCAL VOC2007 defaults to use '11points', while PASCAL
+            VOC2012 defaults to use 'area'.
+            Defaults to '11points'.
+        nproc (int): Processes used for computing TP and FP. If nproc
+            is less than or equal to 1, multiprocessing will not be used.
+            Defaults to 4.
+        drop_class_ap (bool): Whether to drop the class without ground truth
+            when calculating the average precision for each class.
+        classwise (bool): Whether to return the computed results of each
+            class. Defaults to False.
+        **kwargs: Keyword parameters passed to :class:`BaseMetric`.
+    """
+
+    def __init__(self,
+                 iou_thrs: Union[float, List[float]] = 0.5,
+                 scale_ranges: Optional[List[Tuple]] = None,
+                 num_classes: Optional[int] = None,
+                 eval_mode: str = '11points',
+                 nproc: int = 4,
+                 drop_class_ap: bool = True,
+                 classwise: bool = False,
+                 **kwargs):
+        super().__init__(**kwargs)
+
+        if isinstance(iou_thrs, float):
+            iou_thrs = [iou_thrs]
+        assert is_list_of(iou_thrs, float), \
+            '`iou_thrs` should be float or a list of float'
+
+        self.iou_thrs = iou_thrs
+
+        if scale_ranges is None:
+            scale_ranges = [(None, None)]
+        elif (None, None) not in scale_ranges:
+            # We allawys compute the mAP across all scale.
+            scale_ranges.append((None, None))
+        self.scale_ranges = scale_ranges
+
+        area_ranges = []
+        for min_scale, max_scale in self.scale_ranges:
+            min_area = min_scale if min_scale is None else min_scale**2
+            max_area = max_scale if max_scale is None else max_scale**2
+            area_ranges.append((min_area, max_area))
+        self._area_ranges = area_ranges
+
+        self._num_classes = num_classes
+
+        assert eval_mode in ['area', '11points'], \
+            'Unrecognized mode, only "area" and "11points" are supported'
+        self.eval_mode = eval_mode
+
+        self.nproc = nproc
+        self.drop_class_ap = drop_class_ap
+        self.classwise = classwise
+
+        self.num_iou = len(self.iou_thrs)
+        self.num_scale = len(self.scale_ranges)
+
+    @property
+    def num_classes(self) -> int:
+        """Returns the number of classes.
+
+        The number of classes should be set during initialization, otherwise it
+        will be obtained from the 'CLASSES' field in ``self.dataset_meta``.
+
+        Returns:
+            int: The number of classes.
+
+        Raises:
+            RuntimeError: If the num_classes is not set.
+        """
+        if self._num_classes is not None:
+            return self._num_classes
+        if self.dataset_meta and 'CLASSES' in self.dataset_meta:
+            self._num_classes = len(self.dataset_meta['CLASSES'])
+        else:
+            raise RuntimeError(
+                "The `num_claases` is required, and also not found 'CLASSES' "
+                f'in dataset_meta: {self.dataset_meta}')
+        return self._num_classes
+
+    def add(self, predictions: Sequence[Dict], groundtruths: Sequence[Dict]) -> None:  # type: ignore # yapf: disable # noqa: E501
         """Add the intermediate results to ``self._results``.
 
         Args:
@@ -19,7 +162,7 @@ class DOTAMetric(BaseMetric):
                 following keys:
 
                 - bboxes (numpy.ndarray): Shape (N, 5), the predicted
-                  bounding bboxes of this image, in 'xyxy' foramrt.
+                  bounding bboxes of this image, in 'xywha' foramrt.
                 - scores (numpy.ndarray): Shape (N, 1), the predicted scores
                   of bounding boxes.
                 - labels (numpy.ndarray): Shape (N, 1), the predicted labels
@@ -30,29 +173,53 @@ class DOTAMetric(BaseMetric):
                 keys:
 
                 - bboxes (numpy.ndarray): Shape (M, 5), the ground truth
-                  bounding bboxes of this image, in 'xyxy' foramrt.
+                  bounding bboxes of this image, in 'xywha' foramrt.
                 - labels (numpy.ndarray): Shape (M, 1), the ground truth
                   labels of bounding boxes.
                 - bboxes_ignore (numpy.ndarray): Shape (K, 5), the ground
                   truth ignored bounding bboxes of this image,
-                  in 'xyxy' foramrt.
+                  in 'xywha' foramrt.
                 - labels_ignore (numpy.ndarray): Shape (K, 1), the ground
                   truth ignored labels of bounding boxes.
         """
         for prediction, groundtruth in zip(predictions, groundtruths):
             assert isinstance(prediction, dict), 'The prediciton should be ' \
-                f'a sequence of dict, but got a sequence of {type(prediction)}.'
+                f'a sequence of dict, but got a sequence of {type(prediction)}.'  # noqa: E501
             assert isinstance(groundtruth, dict), 'The label should be ' \
-                f'a sequence of dict, but got a sequence of {type(groundtruth)}.'
+                f'a sequence of dict, but got a sequence of {type(groundtruth)}.'  # noqa: E501
             self._results.append((prediction, groundtruth))
 
     @staticmethod
     def _calculate_image_tpfp(
-            pred_bboxes: np.ndarray, gt_bboxes: np.ndarray,
-            ignore_gt_bboxes: np.ndarray, iou_thrs: List[float],
-            area_ranges: List[Tuple[Optional[float], Optional[float]]],
-            use_legacy_coordinate: bool) -> Tuple[np.ndarray, np.ndarray]:
-        pass
+        pred_bboxes: np.ndarray, gt_bboxes: np.ndarray,
+        ignore_gt_bboxes: np.ndarray, iou_thrs: List[float],
+        area_ranges: List[Tuple[Optional[float], Optional[float]]]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Calculate the true positive and false positive on an image.
+
+        Args:
+            pred_bboxes (numpy.ndarray): Predicted bboxes of this image, with
+                shape (N, 6). The scores The predicted score of the bbox is
+                concatenated behind the predicted bbox.
+            gt_bboxes (numpy.ndarray): Ground truth bboxes of this image, with
+                shape (M, 5).
+            ignore_gt_bboxes (numpy.ndarray): Ground truth ignored bboxes of
+                this image, with shape (K, 5).
+            iou_thrs (List[float]): The IoU thresholds.
+            area_ranges (List[Tuple]): The area ranges.
+
+        Returns:
+            tuple (tp, fp):
+
+            - tp (numpy.ndarray): Shape (num_ious, num_scales, N),
+              the true positive flag of each predicted bbox on this image.
+            - fp (numpy.ndarray): Shape (num_ious, num_scales, N),
+              the false positive flag of each predicted bbox on this image.
+
+        Note:
+            This method should be a staticmethod to avoid resource competition
+            during multiple processes.
+        """
         # Step 1. Concatenate `gt_bboxes` and `ignore_gt_bboxes`, then set
         # the `ignore_gt_flags`.
         all_gt_bboxes = np.concatenate((gt_bboxes, ignore_gt_bboxes))
@@ -69,18 +236,14 @@ class DOTAMetric(BaseMetric):
         # within area range are false positives.
         if all_gt_bboxes.shape[0] == 0:
             for idx, (min_area, max_area) in enumerate(area_ranges):
-                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,
-                                                  max_area)
+                area_mask = filter_by_bboxes_area_rotated(
+                    pred_bboxes[:, :5], min_area, max_area)
                 fp[:, idx, area_mask] = 1
             return tp, fp
 
         # Step 4. Calculate the IoUs between the predicted bboxes and the
         # ground truth bboxes.
-        ious = bbox_iou_rotated(
-            pred_bboxes[:, :4],
-            all_gt_bboxes,
-            mode='iou',
-            use_legacy_coordinate=use_legacy_coordinate)
+        ious = bbox_iou_rotated(pred_bboxes[:, :5], all_gt_bboxes)
         # For each pred bbox, the max iou with all gts.
         ious_max = ious.max(axis=1)
         # For each pred bbox, which gt overlaps most with it.
@@ -94,8 +257,8 @@ class DOTAMetric(BaseMetric):
                 # The flags that gt bboxes have been matched.
                 gt_covered_flags = np.zeros(all_gt_bboxes.shape[0], dtype=bool)
                 # The flags that gt bboxes out of area range.
-                gt_area_mask = filter_by_bboxes_area(all_gt_bboxes, min_area,
-                                                     max_area)
+                gt_area_mask = filter_by_bboxes_area_rotated(
+                    all_gt_bboxes, min_area, max_area)
                 ignore_gt_area_flags = ~gt_area_mask
 
                 # Count the prediction bboxes in order of decreasing score.
@@ -115,8 +278,8 @@ class DOTAMetric(BaseMetric):
                             # This gt bbox has been matched and counted as fp.
                             fp[iou_thr_idx, area_idx, pred_bbox_idx] = 1
                     else:
-                        area_mask = filter_by_bboxes_area(
-                            pred_bboxes[pred_bbox_idx, :4], min_area, max_area)
+                        area_mask = filter_by_bboxes_area_rotated(
+                            pred_bboxes[pred_bbox_idx, :5], min_area, max_area)
                         if area_mask:
                             fp[iou_thr_idx, area_idx, pred_bbox_idx] = 1
 
@@ -124,6 +287,17 @@ class DOTAMetric(BaseMetric):
 
     def get_class_predictions(self, predictions: List[dict],
                               class_index: int) -> List:
+        """Get prediciton results of a certain class index.
+
+        Args:
+            predictions (list[dict]): Predictions of all images.
+            class_index (int): Index of a specific class.
+
+        Returns:
+            list[np.ndarray]: A list of predicted bboxes of this class. Each
+            predicted score of the bbox is concatenated behind the predicted
+            bbox.
+        """
         class_preds = []
         for pred in predictions:
             pred_indices = (pred['labels'] == class_index)
@@ -136,6 +310,19 @@ class DOTAMetric(BaseMetric):
 
     def get_class_gts(self, groundtruths: List[dict],
                       class_index: int) -> Tuple:
+        """Get prediciton gt information of a certain class index.
+
+        Args:
+            groundtruths (list[dict]): Groundtruths of all images.
+            class_index (int): Index of a specific class.
+
+        Returns:
+            tuple (class_gts, class_ignore_gts):
+
+            - class_gts (List[numpy.ndarray]): The gt bboxes of this class.
+            - class_ignore_gts (List[numpy.ndarray]): The ignored gt bboxes of
+              this class. This is necessary when counting tp and fp.
+        """
         class_gts = []
         class_ignore_gts = []
 
@@ -152,6 +339,27 @@ class DOTAMetric(BaseMetric):
     def calculate_class_tpfp(self, predictions: List[dict],
                              groundtruths: List[dict], class_index: int,
                              pool: Optional[Pool]) -> Tuple:
+        """Calculate the tp and fp of the given class index.
+
+        Args:
+            predictions (List[dict]): A list of dict. Each dict is the
+                detection result of an image.
+            groundtruths (List[dict]): A list of dict. Each dict is the
+                ground truth of an image.
+            class_index (int): The class index.
+            pool (Optional[Pool]): A instance of :class:`multiprocessing.Pool`.
+                If None, do not use multiprocessing.
+
+        Returns:
+            tuple (tp, fp, num_gts):
+
+            - tp (numpy.ndarray): Shape (num_ious, num_scales, num_pred),
+              the true positive flag of each predicted bbox for this class.
+            - fp (numpy.ndarray): Shape (num_ious, num_scales, num_pred),
+              the false positive flag of each predicted bbox for this class.
+            - num_gts (numpy.ndarray): Shape (num_ious, num_scales), the
+              number of ground truths.
+        """
         class_preds = self.get_class_predictions(predictions, class_index)
         class_gts, class_ignore_gts = self.get_class_gts(
             groundtruths, class_index)
@@ -159,10 +367,13 @@ class DOTAMetric(BaseMetric):
             num_images = len(class_preds)
             tpfp_list = pool.starmap(
                 self._calculate_image_tpfp,
-                zip(class_preds, class_gts, class_ignore_gts,
+                zip(
+                    class_preds,
+                    class_gts,
+                    class_ignore_gts,
                     [self.iou_thrs] * num_images,
                     [self._area_ranges] * num_images,
-                    [self.use_legacy_coordinate] * num_images))
+                ))
         else:
             tpfp_list = []
             for img_idx in range(len(class_preds)):
@@ -170,8 +381,7 @@ class DOTAMetric(BaseMetric):
                                                   class_gts[img_idx],
                                                   class_ignore_gts[img_idx],
                                                   self.iou_thrs,
-                                                  self._area_ranges,
-                                                  self.use_legacy_coordinate)
+                                                  self._area_ranges)
                 tpfp_list.append(tpfp)
 
         image_tp_list, image_fp_list = tuple(zip(*tpfp_list))
@@ -180,16 +390,114 @@ class DOTAMetric(BaseMetric):
         fp = np.concatenate(image_fp_list, axis=2)[..., sorted_indices]
         num_gts = np.zeros((self.num_iou, self.num_scale), dtype=int)
         for idx, (min_area, max_area) in enumerate(self._area_ranges):
-            area_mask = filter_by_bboxes_area(
+            area_mask = filter_by_bboxes_area_rotated(
                 np.vstack(class_gts), min_area, max_area)
             num_gts[:, idx] = np.sum(area_mask)
 
         return tp, fp, num_gts
 
     def compute_metric(self, results: list) -> dict:
+        """Compute the DOTA metric.
+
+        Args:
+            results (List[tuple]): A list of tuple. Each tuple is the
+                prediction and ground truth of an image. This list has already
+                been synced across all ranks.
+
+        Returns:
+            dict: The computed metric, with the following keys:
+
+            - mAP, the averaged across all IoU thresholds and all class.
+            - mAP@{IoU}, the mAP of the specified IoU threshold.
+            - mAP@{scale_range}, the mAP of the specified scale range.
+            - classwise, the evaluation results of each class.
+              This would be returned if ``self.classwise`` is True.
+        """
         predictions, groundtruths = zip(*results)
         nproc = min(self.nproc, len(predictions))
         if nproc > 1:
             pool = Pool(nproc)
         else:
             pool = None  # type: ignore
+
+        results_per_class = []
+        for class_index in range(self.num_classes):
+            # Calculate tp, fp and num_gts.
+            tp, fp, num_gts = self.calculate_class_tpfp(
+                predictions, groundtruths, class_index, pool)
+
+            # Calculate recalls and precisions.
+            tp_cumsum = np.cumsum(tp, axis=2)
+            fp_cumsum = np.cumsum(fp, axis=2)
+            eps = np.finfo(np.float32).eps
+            precisions = tp_cumsum / np.maximum((tp_cumsum + fp_cumsum), eps)
+            recalls = tp_cumsum / np.maximum(num_gts[..., np.newaxis], eps)
+
+            # Calculate average precision per `iou_thr` and `scale_range`.
+            ap = np.zeros((self.num_iou, self.num_scale), dtype=np.float32)
+            for i in range(self.num_iou):
+                for j in range(self.num_scale):
+                    ap[i, j] = calculate_average_precision(
+                        recalls[i, j], precisions[i, j], self.eval_mode)
+
+            results_per_class.append({
+                'num_gts': num_gts,
+                'num_dets': tp.shape[-1],
+                'recalls': recalls,
+                'precisions': precisions,
+                'ap': ap,
+            })
+
+        if pool is not None:
+            pool.close()
+
+        eval_results = self._aggregate_results(results_per_class)
+        if self.classwise:
+            eval_results['classwise_result'] = results_per_class
+
+        return eval_results
+
+    def _aggregate_results(self, results_per_class: List[dict]) -> dict:
+        """Aggregate class-wise results and return a dictionary.
+
+        Args:
+            results_per_class (List[dict]): The class-wise evaluate results.
+
+        Returns:
+            dict: The aggregated metric results, with the following keys:
+
+            - mAP, the averaged across all IoU thresholds and all class.
+            - mAP@{IoU}, the mAP of the specified IoU threshold.
+            - mAP@{scale_range}, the mAP of the specified scale range.
+        """
+        eval_results = {}
+
+        # Calculate `mAP@{iou_thr}` (while scale_range is None) for each
+        # `iou_thrs`.
+        for i, iou_thr in enumerate(self.iou_thrs):
+            for j, scale_range in enumerate(self.scale_ranges):
+                if scale_range != (None, None):
+                    continue
+                aps = [
+                    res['ap'][i][j] for res in results_per_class
+                    if res['num_gts'][i][j] > 0 or not self.drop_class_ap
+                ]
+                eval_results[f'mAP@{iou_thr}'] = np.array(aps).mean().item()
+
+        # Calculate `mAP@{scale_range}` and `mAP` (while scale_range is None)
+        # overall `iou_thrs`.
+        for j, scale_range in enumerate(self.scale_ranges):
+            ap_per_ious = []
+            for i in range(len(self.iou_thrs)):
+                aps = [
+                    res['ap'][i][j] for res in results_per_class
+                    if res['num_gts'][i][j] > 0 or not self.drop_class_ap
+                ]
+                ap_per_ious.append(np.array(aps).mean().item())
+            if scale_range == (None, None):
+                key = 'mAP'
+            else:
+                key = f'mAP@{scale_range}'
+            eval_results[key] = np.array(ap_per_ious).mean().item()
+
+        return eval_results

--- a/mmeval/metrics/dota_metric.py
+++ b/mmeval/metrics/dota_metric.py
@@ -1,0 +1,196 @@
+import numpy as np
+from multiprocessing.pool import Pool
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+from mmeval.core.base_metric import BaseMetric
+from .utils.bbox_iou_rotated import bbox_iou_rotated
+
+
+class DOTAMetric(BaseMetric):
+    def add(self, predictions: Sequence[Dict], groundtruths: Sequence[Dict]) -> None:
+        """Add the intermediate results to ``self._results``.
+
+        Args:
+            predictions (Sequence[Dict]):  A sequence of dict. Each dict
+                representing a detection result for an image, with the
+                following keys:
+
+                - bboxes (numpy.ndarray): Shape (N, 5), the predicted
+                  bounding bboxes of this image, in 'xyxy' foramrt.
+                - scores (numpy.ndarray): Shape (N, 1), the predicted scores
+                  of bounding boxes.
+                - labels (numpy.ndarray): Shape (N, 1), the predicted labels
+                  of bounding boxes.
+
+            groundtruths (Sequence[Dict]):  A sequence of dict. Each dict
+                represents a groundtruths for an image, with the following
+                keys:
+
+                - bboxes (numpy.ndarray): Shape (M, 5), the ground truth
+                  bounding bboxes of this image, in 'xyxy' foramrt.
+                - labels (numpy.ndarray): Shape (M, 1), the ground truth
+                  labels of bounding boxes.
+                - bboxes_ignore (numpy.ndarray): Shape (K, 5), the ground
+                  truth ignored bounding bboxes of this image,
+                  in 'xyxy' foramrt.
+                - labels_ignore (numpy.ndarray): Shape (K, 1), the ground
+                  truth ignored labels of bounding boxes.
+        """
+        for prediction, groundtruth in zip(predictions, groundtruths):
+            assert isinstance(prediction, dict), 'The prediciton should be ' \
+                f'a sequence of dict, but got a sequence of {type(prediction)}.'
+            assert isinstance(groundtruth, dict), 'The label should be ' \
+                f'a sequence of dict, but got a sequence of {type(groundtruth)}.'
+            self._results.append((prediction, groundtruth))
+
+    @staticmethod
+    def _calculate_image_tpfp(
+        pred_bboxes: np.ndarray,
+        gt_bboxes: np.ndarray,
+        ignore_gt_bboxes: np.ndarray,
+        iou_thrs: List[float],
+        area_ranges: List[Tuple[Optional[float], Optional[float]]],
+        use_legacy_coordinate: bool) -> Tuple[np.ndarray, np.ndarray ]:
+        pass
+        # Step 1. Concatenate `gt_bboxes` and `ignore_gt_bboxes`, then set
+        # the `ignore_gt_flags`.
+        all_gt_bboxes = np.concatenate((gt_bboxes, ignore_gt_bboxes))
+        ignore_gt_flags = np.concatenate((np.zeros(
+            (gt_bboxes.shape[0], 1),
+            dtype=bool), np.ones((ignore_gt_bboxes.shape[0], 1), dtype=bool)))
+        
+        # Step 2. Initialize the `tp` and `fp` arrays.
+        num_preds = pred_bboxes.shape[0]
+        tp = np.zeros((len(iou_thrs), len(area_ranges), num_preds))
+        fp = np.zeros((len(iou_thrs), len(area_ranges), num_preds))
+
+        # Step 3. If there are no gt bboxes in this image, then all pred bboxes
+        # within area range are false positives.
+        if all_gt_bboxes.shape[0] == 0:
+            for idx, (min_area, max_area) in enumerate(area_ranges):
+                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,max_area)
+                fp[:, idx, area_mask] = 1
+            return tp,fp
+
+        # Step 4. Calculate the IoUs between the predicted bboxes and the
+        # ground truth bboxes.
+        ious = bbox_iou_rotated(
+            pred_bboxes[:, :4],
+            all_gt_bboxes,
+            mode='iou',
+            use_legacy_coordinate=use_legacy_coordinate)
+        # For each pred bbox, the max iou with all gts.
+        ious_max = ious.max(axis=1)
+        # For each pred bbox, which gt overlaps most with it.
+        ious_argmax = ious.argmax(axis=1)
+        # Sort all pred bbox in descending order by scores.
+        sorted_indices = np.argsort(-pred_bboxes[:, -1])
+
+        # Step 5. Count the `tp` and `fp` of each iou threshold and area range.
+        for iou_thr_idx, iou_thr in enumerate(iou_thrs):
+            for area_idx, (min_area, max_area) in enumerate(area_ranges):
+                # The flags that gt bboxes have been matched.
+                gt_covered_flags = np.zeros(all_gt_bboxes.shape[0], dtype=bool)
+                # The flags that gt bboxes out of area range.
+                gt_area_mask = filter_by_bboxes_area(all_gt_bboxes, min_area,
+                                                     max_area)
+                ignore_gt_area_flags = ~gt_area_mask
+
+                # Count the prediction bboxes in order of decreasing score.
+                for pred_bbox_idx in sorted_indices:
+                    if ious_max[pred_bbox_idx] >= iou_thr:
+                        matched_gt_idx = ious_argmax[pred_bbox_idx]
+                        # Ignore the pred bbox that match an ignored gt bbox.
+                        if ignore_gt_flags[matched_gt_idx]:
+                            continue
+                        # Ignore the pred bbox that is out of area range.
+                        if ignore_gt_area_flags[matched_gt_idx]:
+                            continue
+                        if not gt_covered_flags[matched_gt_idx]:
+                            tp[iou_thr_idx, area_idx, pred_bbox_idx] = 1
+                            gt_covered_flags[matched_gt_idx] = True
+                        else:
+                            # This gt bbox has been matched and counted as fp.
+                            fp[iou_thr_idx, area_idx, pred_bbox_idx] = 1
+                    else:
+                        area_mask = filter_by_bboxes_area(
+                            pred_bboxes[pred_bbox_idx, :4], min_area, max_area)
+                        if area_mask:
+                            fp[iou_thr_idx, area_idx, pred_bbox_idx] = 1
+
+        return tp, fp
+        
+    def get_class_predictions(self,
+                                predictions: List[dict],
+                                class_index: int) -> List:
+        class_preds = []
+        for pred in predictions:
+            pred_indices = (pred['labels'] == class_index)
+            pred_bboxes_info = np.concatenate(
+                (pred['bboxes'][pred_indices, :],
+                 pred['scores'][pred_indices].reshape((-1, 1))),
+                axis=1)
+            class_preds.append(pred_bboxes_info)
+        return class_preds
+
+    def get_class_gts(self, groundtruths: List[dict],
+                      class_index: int) -> Tuple:
+        class_gts = []
+        class_ignore_gts = []
+
+        for gt in groundtruths:
+            gt_indices = (gt['labels'] == class_index)
+            gt_bboxes = gt['bboxes'][gt_indices, :]
+            ignore_gt_indices = (gt['labels_ignore'] == class_index)
+            ignore_gt_bboxes = gt['bboxes_ignore'][ignore_gt_indices, :]
+            class_gts.append(gt_bboxes)
+            class_ignore_gts.append(ignore_gt_bboxes)
+        
+        return class_gts, class_ignore_gts
+
+    def calculate_class_tpfp(self,
+                            predictions: List[dict],
+                            groundtruths: List[dict],
+                            class_index: int,
+                            pool: Optional[Pool]) -> Tuple:
+        class_preds = self.get_class_predictions(predictions, class_index)
+        class_gts, class_ignore_gts = self.get_class_gts(
+            groundtruths, class_index)
+        if pool is not None:
+            num_images = len(class_preds)
+            tpfp_list = pool.starmap(
+                self._calculate_image_tpfp,
+                zip(class_preds, class_gts, class_ignore_gts,
+                    [self.iou_thrs] * num_images,
+                    [self._area_ranges] * num_images,
+                    [self.use_legacy_coordinate] * num_images))
+        else:
+            tpfp_list = []
+            for img_idx in range(len(class_preds)):
+                tpfp = self._calculate_image_tpfp(class_preds       [img_idx],
+                                                  class_gts[img_idx],
+                                                  class_ignore_gts[img_idx],
+                                                  self.iou_thrs,
+                                                  self._area_ranges,
+                                                  self.use_legacy_coordinate)
+                tpfp_list.append(tpfp)
+        
+        image_tp_list, image_fp_list = tuple(zip(*tpfp_list))
+        sorted_indices = np.argsort(-np.vstack(class_preds)[:, -1])
+        tp = np.concatenate(image_tp_list, axis=2)[..., sorted_indices]
+        fp = np.concatenate(image_fp_list, axis=2)[..., sorted_indices]
+        num_gts = np.zeros((self.num_iou, self.num_scale), dtype=int)
+        for idx, (min_area, max_area) in enumerate(self._area_ranges):
+            area_mask = filter_by_bboxes_area(
+                np.vstack(class_gts), min_area, max_area)
+            num_gts[:, idx] = np.sum(area_mask)
+        
+        return tp, fp, num_gts
+
+    def compute_metric(self, results: list) -> dict:
+        predictions, groundtruths = zip(*results)
+        nproc = min(self.nproc, len(predictions))
+        if nproc > 1:
+            pool = Pool(nproc)
+        else:
+            pool = None  # type: ignore

--- a/mmeval/metrics/utils/bbox_iou_rotated.py
+++ b/mmeval/metrics/utils/bbox_iou_rotated.py
@@ -13,7 +13,7 @@ def le90_to_oc(bboxes: np.ndarray):
     Returns:
         np.ndarray: An numpy.ndarray with the same shape of input.
     """
-    assert bboxes.shape[1] == 5, "The boxes' shape[-1] should be 5"
+    assert bboxes.shape[1] == 5, 'The boxes shape should be [N,5]'
 
     # a mask to indicate if input angles belong to (0,pi/2]
     mask = bboxes[:, 4] <= 0.0

--- a/mmeval/metrics/utils/bbox_iou_rotated.py
+++ b/mmeval/metrics/utils/bbox_iou_rotated.py
@@ -19,9 +19,7 @@ def le90_to_oc(bboxes: np.ndarray):
     mask = bboxes[:, 4] <= 0.0
     # convert angle
     ret_bboxes = bboxes.copy()
-    ret_bboxes[:,
-               4] = ret_bboxes[:,
-                               4] + np.pi / 2 * np.ones(bboxes.shape[0]) * mask
+    ret_bboxes[:, 4] += np.pi / 2 * np.ones(bboxes.shape[0]) * mask
     # convert w and h
     temp = ret_bboxes[mask]
     temp[:, [2, 3]] = temp[:, [3, 2]]

--- a/mmeval/metrics/utils/bbox_iou_rotated.py
+++ b/mmeval/metrics/utils/bbox_iou_rotated.py
@@ -1,10 +1,11 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 '''
 Author: Ghost 1432072586@qq.com
 Date: 2022-12-01 16:30:30
 LastEditors: Ghost 1432072586@qq.com
 LastEditTime: 2022-12-01 16:39:54
 FilePath: /mmeval/mmeval/metrics/utils/bbox_iou_rotated.py
-Description: 
+Description:
 '''
 import numpy as np
 

--- a/mmeval/metrics/utils/bbox_iou_rotated.py
+++ b/mmeval/metrics/utils/bbox_iou_rotated.py
@@ -1,0 +1,34 @@
+'''
+Author: Ghost 1432072586@qq.com
+Date: 2022-12-01 16:30:30
+LastEditors: Ghost 1432072586@qq.com
+LastEditTime: 2022-12-01 16:39:54
+FilePath: /mmeval/mmeval/metrics/utils/bbox_iou_rotated.py
+Description: 
+'''
+import numpy as np
+
+
+def bbox_iou_rotated(bboxes1: np.ndarray,
+                     bboxes2: np.ndarray,
+                     mode: str = 'iou',
+                     aligned: bool = False,
+                     clockwise: bool = True) -> np.ndarray:
+    assert mode in ['iou', 'iof']
+    mode_dict = {'iou': 0, 'iof': 1}
+    mode_flag = mode_dict[mode]
+    rows = bboxes1.size(0)
+    cols = bboxes2.size(0)
+    if aligned:
+        ious = np.zeros(rows)
+    else:
+        ious = np.zeros(rows * cols)
+    if not clockwise:
+        flip_mat = np.ones(bboxes1.shape[-1])
+        flip_mat[-1] = -1
+        bboxes1 = bboxes1 * flip_mat
+        bboxes2 = bboxes2 * flip_mat
+
+    if not aligned:
+        ious = ious.view(rows, cols)
+    return ious

--- a/mmeval/metrics/utils/bbox_iou_rotated.py
+++ b/mmeval/metrics/utils/bbox_iou_rotated.py
@@ -1,35 +1,98 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-'''
-Author: Ghost 1432072586@qq.com
-Date: 2022-12-01 16:30:30
-LastEditors: Ghost 1432072586@qq.com
-LastEditTime: 2022-12-01 16:39:54
-FilePath: /mmeval/mmeval/metrics/utils/bbox_iou_rotated.py
-Description:
-'''
+import cv2
 import numpy as np
+
+
+def le90_to_oc(bboxes: np.ndarray):
+    """convert bboxes with le90 version to opencv version.
+
+    Args:
+        bboxes (np.ndarray): The shape of bboxes should be [N,5],
+        the format is [x,y,w,h,angle]
+
+    Returns:
+        np.ndarray: An numpy.ndarray with the same shape of input.
+    """
+    assert bboxes.shape[1] == 5, "The boxes' shape[-1] should be 5"
+
+    # a mask to indicate if input angles belong to (0,pi/2]
+    mask = bboxes[:, 4] <= 0.0
+    # convert angle
+    ret_bboxes = bboxes.copy()
+    ret_bboxes[:,
+               4] = ret_bboxes[:,
+                               4] + np.pi / 2 * np.ones(bboxes.shape[0]) * mask
+    # convert w and h
+    temp = ret_bboxes[mask]
+    temp[:, [2, 3]] = temp[:, [3, 2]]
+    ret_bboxes[mask] = temp
+    # rad to angle
+    ret_bboxes[:, 4] = ret_bboxes[:, 4] * 180.0 / np.pi
+    return ret_bboxes
+
+
+def calculate_bboxes_area_rotated(bboxes: np.ndarray) -> np.ndarray:
+    """Calculate area of rotated bounding boxes.
+
+    Args:
+        bboxes (np.ndarray): The bboxes with shape (n, 5) or (5, )
+        in 'xywha'format.
+
+    Returns:
+        np.ndarray: The area of bboxes.
+    """
+    bboxes_w = bboxes[..., 2]
+    bboxes_h = bboxes[..., 3]
+    areas = bboxes_w * bboxes_h
+    return areas
 
 
 def bbox_iou_rotated(bboxes1: np.ndarray,
                      bboxes2: np.ndarray,
-                     mode: str = 'iou',
-                     aligned: bool = False,
                      clockwise: bool = True) -> np.ndarray:
-    assert mode in ['iou', 'iof']
-    mode_dict = {'iou': 0, 'iof': 1}
-    mode_flag = mode_dict[mode]
-    rows = bboxes1.size(0)
-    cols = bboxes2.size(0)
-    if aligned:
-        ious = np.zeros(rows)
-    else:
-        ious = np.zeros(rows * cols)
+    """Calculate the overlap between each rotated bbox of bboxes1 and bboxes2.
+
+    Args:
+        bboxes1 (np.ndarray): The bboxes with shape (n, 5) in 'xywha' format.
+        bboxes2 (np.ndarray): The bboxes with shape (k, 5) in 'xywha' format.
+        clockwise (bool, optional): flag indicating whether the positive
+        angular orientation is clockwise. Defaults to True.
+
+    Returns:
+        np.ndarray: IoUs with shape (n, k).
+    """
+    bboxes1 = bboxes1.astype(np.float32)
+    bboxes2 = bboxes2.astype(np.float32)
+    rows = bboxes1.shape[0]
+    cols = bboxes2.shape[0]
+    ious = np.zeros((rows, cols), dtype=np.float32)
+
+    if rows * cols == 0:
+        return ious
+
     if not clockwise:
         flip_mat = np.ones(bboxes1.shape[-1])
         flip_mat[-1] = -1
         bboxes1 = bboxes1 * flip_mat
         bboxes2 = bboxes2 * flip_mat
 
-    if not aligned:
-        ious = ious.view(rows, cols)
+    # convert angle version
+    bboxes1 = le90_to_oc(bboxes1)
+    bboxes2 = le90_to_oc(bboxes2)
+
+    area1 = bboxes1[:, 2] * bboxes1[:, 3]
+    area2 = bboxes2[:, 2] * bboxes2[:, 3]
+    for i, box1 in enumerate(bboxes1):
+        r1 = ((box1[0], box1[1]), (box1[2], box1[3]), box1[4])
+        for j, box2 in enumerate(bboxes2):
+            r2 = ((box2[0], box2[1]), (box2[2], box2[3]), box2[4])
+            int_pts = cv2.rotatedRectangleIntersection(r1, r2)[1]
+            if int_pts is not None:
+                order_pts = cv2.convexHull(int_pts, returnPoints=True)
+                int_area = cv2.contourArea(order_pts)
+                inter = int_area * 1.0 / (
+                    area1[i] + area2[j] - int_area + 1e-5)
+                ious[i][j] = inter
+            else:
+                ious[i][j] = 0.0
     return ious

--- a/mmeval/metrics/voc_map.py
+++ b/mmeval/metrics/voc_map.py
@@ -290,7 +290,8 @@ class VOCMeanAP(BaseMetric):
         # within area range are false positives.
         if all_gt_bboxes.shape[0] == 0:
             for idx, (min_area, max_area) in enumerate(area_ranges):
-                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,max_area)
+                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,
+                                                  max_area)
                 fp[:, idx, area_mask] = 1
             return tp, fp
 

--- a/mmeval/metrics/voc_map.py
+++ b/mmeval/metrics/voc_map.py
@@ -290,8 +290,7 @@ class VOCMeanAP(BaseMetric):
         # within area range are false positives.
         if all_gt_bboxes.shape[0] == 0:
             for idx, (min_area, max_area) in enumerate(area_ranges):
-                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,
-                                                  max_area)
+                area_mask = filter_by_bboxes_area(pred_bboxes[:, :4], min_area,max_area)
                 fp[:, idx, area_mask] = 1
             return tp, fp
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,9 @@ BASED_ON_STYLE = pep8
 BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = true
 SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 
+# ignore-words-list needs to be lowercase format. For example, if we want to
+# ignore word "BA", then we need to append "ba" to ignore-words-list rather
+# than "BA"
 [codespell]
 skip = *.ipynb
 quiet-level = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
+ignore-words-list = dota
 
 [mypy]
 allow_redefinition = True

--- a/tests/test_metrics/test_dota_metric.py
+++ b/tests/test_metrics/test_dota_metric.py
@@ -53,7 +53,7 @@ def _gen_groundtruth(num_gt=10,
 # yapf: enable
 def test_metric_interface(metric_kwargs):
     num_classes = 10
-    dota_metric = DOTAMetric(num_classes=num_classes)
+    dota_metric = DOTAMetric(num_classes=num_classes, **metric_kwargs)
     assert isinstance(dota_metric, BaseMetric)
     metric_results = dota_metric(
         predictions=[

--- a/tests/test_metrics/test_dota_metric.py
+++ b/tests/test_metrics/test_dota_metric.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+
+from mmeval.core.base_metric import BaseMetric
+from mmeval.metrics import DOTAMetric
+
+
+def _gen_rotated_bboxes(num_bboxes, img_w, img_h):
+    x = np.random.rand(num_bboxes, ) * img_w
+    y = np.random.rand(num_bboxes, ) * img_h
+    w = np.random.rand(num_bboxes, ) * (img_w - x)
+    h = np.random.rand(num_bboxes, ) * (img_h - y)
+    a = np.random.rand(num_bboxes, ) * np.pi / 2
+    return np.stack([x, y, w, h, a], axis=1)
+
+
+def _gen_prediction(num_pred=10, num_classes=10, img_w=256, img_h=256):
+    prediction = {
+        'bboxes': _gen_rotated_bboxes(num_pred, img_w, img_h),
+        'scores': np.random.rand(num_pred, ),
+        'labels': np.random.randint(0, num_classes, size=(num_pred, ))
+    }
+    return prediction
+
+
+def _gen_groundtruth(num_gt=10,
+                     num_ignored_gt=2,
+                     num_classes=10,
+                     img_w=256,
+                     img_h=256):
+    groundtruth = {
+        'bboxes': _gen_rotated_bboxes(num_gt, img_w, img_h),
+        'labels': np.random.randint(0, num_classes, size=(num_gt, )),
+        'bboxes_ignore': _gen_rotated_bboxes(num_ignored_gt, img_w, img_h),
+        'labels_ignore':
+        np.random.randint(0, num_classes, size=(num_ignored_gt, ))
+    }
+    return groundtruth
+
+
+# yapf: disable
+@pytest.mark.parametrize(
+    argnames='metric_kwargs',
+    argvalues=[
+        {},
+        {'iou_thrs': [0.5, 0.75]},
+        {'scale_ranges': [(20, 40)]},
+        {'iou_thrs': [0.5, 0.75], 'scale_ranges': [(20, 40)]},
+        {'eval_mode': '11points'},
+        {'eval_mode': 'area'},
+        {'nproc': -1},
+    ])
+# yapf: enable
+def test_metric_interface(metric_kwargs):
+    num_classes = 10
+    dota_metric = DOTAMetric(num_classes=num_classes)
+    assert isinstance(dota_metric, BaseMetric)
+    metric_results = dota_metric(
+        predictions=[
+            _gen_prediction(num_classes=num_classes) for _ in range(10)
+        ],
+        groundtruths=[
+            _gen_groundtruth(num_classes=num_classes) for _ in range(10)
+        ],
+    )
+    assert isinstance(metric_results, dict)
+    assert 'mAP' in metric_results
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-vv', '--capture=no'])


### PR DESCRIPTION
## Motivation

add DOTA evaluation metric.

## Modification

add DOTA evaluation metric. 

## Use cases 
```
import numpy as np
from mmeval import DOTAMetric
num_classes = 15
dota_metric = DOTAMetric(num_classes=15)
def _gen_bboxes(num_bboxes, img_w=256, img_h=256):
    # random generate bounding boxes in 'xywha' formart.
    x = np.random.rand(num_bboxes, ) * img_w
    y = np.random.rand(num_bboxes, ) * img_h
    w = np.random.rand(num_bboxes, ) * (img_w - x)
    h = np.random.rand(num_bboxes, ) * (img_h - y)
    a = np.random.rand(num_bboxes, ) * np.pi / 2
    return np.stack([x, y, w, h, a], axis=1)
  prediction = {
        'bboxes': _gen_bboxes(10),
        'scores': np.random.rand(10, ),
        'labels': np.random.randint(0, num_classes, size=(10, ))
 }
groundtruth = {
        'bboxes': _gen_bboxes(10),
        'labels': np.random.randint(0, num_classes, size=(10, )),
        'bboxes_ignore': _gen_bboxes(5),
        'labels_ignore': np.random.randint(0, num_classes, size=(5, ))
}
dota_metric(predictions=[prediction, ], groundtruths=[groundtruth, ])  # doctest: +ELLIPSIS  # noqa: E501
```