### PR TITLE
[Fix] Fix CI failed caused by OneFlow installation and new version of NumPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
             python -V
             pip install torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html
             pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-            pip install --pre oneflow -f https://staging.oneflow.info/branch/master/cu112 "numpy<1.24.0"
+            pip install --pre oneflow -f https://staging.oneflow.info/branch/master/cu112 "numpy<1.24.0" || true
       - run:
           name: Install mmeval and dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,8 @@ jobs:
       - run:
           name: Install OneFlow via pip
           command: |
-            pip install -f https://release.oneflow.info oneflow==0.8.0+cpu "numpy<1.24.0"
+            # Install Oneflow often failed, we just skip it if failed.
+            pip install -f https://release.oneflow.info oneflow==0.8.0+cpu "numpy<1.24.0" || true
       - run:
           name: Install mmeval and dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
             python -V
             pip install torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html
             pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+            # Install Oneflow often failed, we just skip it if failed.
             pip install --pre oneflow -f https://staging.oneflow.info/branch/master/cu112 "numpy<1.24.0" || true
       - run:
           name: Install mmeval and dependencies

--- a/mmeval/metrics/_vendor/ava_evaluation/metrics.py
+++ b/mmeval/metrics/_vendor/ava_evaluation/metrics.py
@@ -35,7 +35,7 @@ def compute_precision_recall(scores, labels, num_gt):
             instances. This value is None if no ground truth labels are
             present.
     """
-    if (not isinstance(labels, np.ndarray) or labels.dtype != np.bool
+    if (not isinstance(labels, np.ndarray) or labels.dtype != np.bool_
             or len(labels.shape) != 1):
         raise ValueError('labels must be single dimension bool numpy array')
 

--- a/mmeval/metrics/_vendor/ava_evaluation/metrics.py
+++ b/mmeval/metrics/_vendor/ava_evaluation/metrics.py
@@ -35,7 +35,7 @@ def compute_precision_recall(scores, labels, num_gt):
             instances. This value is None if no ground truth labels are
             present.
     """
-    if (not isinstance(labels, np.ndarray) or labels.dtype != np.bool_
+    if (not isinstance(labels, np.ndarray) or labels.dtype != bool
             or len(labels.shape) != 1):
         raise ValueError('labels must be single dimension bool numpy array')
 
@@ -90,7 +90,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError('precision and recall must be numpy array')
-    if precision.dtype != np.float_ or recall.dtype != np.float_:
+    if precision.dtype != float or recall.dtype != float:
         raise ValueError('input must be float numpy array.')
     if len(precision) != len(recall):
         raise ValueError('precision and recall must be of the same size.')

--- a/mmeval/metrics/_vendor/ava_evaluation/metrics.py
+++ b/mmeval/metrics/_vendor/ava_evaluation/metrics.py
@@ -90,7 +90,7 @@ def compute_average_precision(precision, recall):
     if not isinstance(precision, np.ndarray) or not isinstance(
             recall, np.ndarray):
         raise ValueError('precision and recall must be numpy array')
-    if precision.dtype != np.float or recall.dtype != np.float:
+    if precision.dtype != np.float_ or recall.dtype != np.float_:
         raise ValueError('input must be float numpy array.')
     if len(precision) != len(recall):
         raise ValueError('precision and recall must be of the same size.')

--- a/mmeval/metrics/coco_detection.py
+++ b/mmeval/metrics/coco_detection.py
@@ -92,7 +92,7 @@ class COCODetectionMetric(BaseMetric):
         ...         bbox = bbox.astype(np.int32)
         ...         box_mask = (np.random.rand(
         ...             bbox[3] - bbox[1],
-        ...             bbox[2] - bbox[0]) > 0.3).astype(np.int)
+        ...             bbox[2] - bbox[0]) > 0.3).astype(np.int32)
         ...         mask[bbox[1]:bbox[3], bbox[0]:bbox[2]] = box_mask
         ...         masks.append(
         ...             mask_util.encode(

--- a/mmeval/metrics/hmean_iou.py
+++ b/mmeval/metrics/hmean_iou.py
@@ -184,7 +184,7 @@ class HmeanIoU(BaseMetric):
             pred_polys = polys2shapely(pred_polygons)
             pred_scores = np.array(pred_scores, dtype=np.float32)
             gt_polys = polys2shapely(gt_polygons)
-            gt_ignore_flags = np.array(gt_ignore_flags, dtype=bool)
+            gt_ignore_flags = np.array(gt_ignore_flags, dtype=np.bool_)
 
             self._results.append(
                 (pred_polys, pred_scores, gt_polys, gt_ignore_flags))

--- a/mmeval/metrics/hmean_iou.py
+++ b/mmeval/metrics/hmean_iou.py
@@ -184,7 +184,7 @@ class HmeanIoU(BaseMetric):
             pred_polys = polys2shapely(pred_polygons)
             pred_scores = np.array(pred_scores, dtype=np.float32)
             gt_polys = polys2shapely(gt_polygons)
-            gt_ignore_flags = np.array(gt_ignore_flags, dtype=np.bool_)
+            gt_ignore_flags = np.array(gt_ignore_flags, dtype=bool)
 
             self._results.append(
                 (pred_polys, pred_scores, gt_polys, gt_ignore_flags))

--- a/mmeval/metrics/multi_label.py
+++ b/mmeval/metrics/multi_label.py
@@ -430,7 +430,7 @@ class MultiLabelMetric(MultiLabelMixin, BaseMetric):
             pos_inds = (preds >= self.thr).long()
         else:
             # top-k labels will be predicted positive for any example
-            _, topk_indices = preds.topk(self.topk)
+            _, topk_indices = preds.topk(self.topk, dim=-1)
             pos_inds = flow.zeros_like(preds).scatter_(1, topk_indices, 1)
             pos_inds = pos_inds.long()
 

--- a/tests/test_metrics/test_coco_detection_metric.py
+++ b/tests/test_metrics/test_coco_detection_metric.py
@@ -155,7 +155,7 @@ def _gen_masks(bboxes, img_w=256, img_h=256):
         mask = np.zeros((img_h, img_w))
         bbox = bbox.astype(np.int32)
         box_mask = (np.random.rand(bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                    0.3).astype(np.int)
+                    0.3).astype(np.int32)
         mask[bbox[1]:bbox[3], bbox[0]:bbox[2]] = box_mask
         masks.append(
             coco_wrapper.mask_util.encode(


### PR DESCRIPTION
## Motivation
The CI failed with the following 2 reasons:
1. OneFlow OSS download could be failed.
2. The new version release of NumPy (1.24.1)

## Modification
According to the NumPy deprecations: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
![image](https://user-images.githubusercontent.com/32220263/210718319-e663caf1-e94b-4052-94c0-95b359259a30.png)

- Using `bool` instead of `np.bool`
- Using `float` instead of `np.float`
- Using `np.int32` instead of `np.int` (Consistent with context)
- Skip OneFlow installation if failed