### PR TITLE
[Fix] Fix import error in python3.6

### DIFF
--- a/mmeval/core/dispatcher.py
+++ b/mmeval/core/dispatcher.py
@@ -213,7 +213,7 @@ class _MMEvalDispatcher(plum.Dispatcher):
 
         # Recursively traverse nested type hints.
         if getattr(annotation, '__module__', None) == 'typing' \
-                and hasattr(annotation, '__args__'):
+                and getattr(annotation, '__args__'):
             new_tp_args = []
             for tp_arg in annotation.__args__:
                 new_tp_arg = self._traverse_type_hints(tp_arg)

--- a/mmeval/core/dispatcher.py
+++ b/mmeval/core/dispatcher.py
@@ -213,7 +213,7 @@ class _MMEvalDispatcher(plum.Dispatcher):
 
         # Recursively traverse nested type hints.
         if getattr(annotation, '__module__', None) == 'typing' \
-                and getattr(annotation, '__args__'):
+                and getattr(annotation, '__args__', None) is not None:
             new_tp_args = []
             for tp_arg in annotation.__args__:
                 new_tp_arg = self._traverse_type_hints(tp_arg)


### PR DESCRIPTION
## Motivation

If we install mmeval with python3.6.x, it will crash to call `from mmeval import Accuracy`.

![image](https://user-images.githubusercontent.com/32220263/211963608-71f7c0c5-5a60-4dc3-9abf-587674aa6804.png)


## Modification

Replace `hasattr` with `getattr` when recursively traversing nested type hints in dispatcher.

![image](https://user-images.githubusercontent.com/32220263/211969738-c816bec9-5210-442a-850e-081d1141f769.png)
