### PR TITLE
[Fix] Fix psnr,snr,ssim,mae and mse fail to compute on videos

### DIFF
--- a/mmeval/metrics/mae.py
+++ b/mmeval/metrics/mae.py
@@ -55,9 +55,11 @@ class MeanAbsoluteError(BaseMetric):
             if masks is None:
                 result = self.compute_mae(prediction, groundtruth)
             else:
+                # when prediction is a image
                 if len(prediction.shape) <= 3:
                     result = self.compute_mae(prediction, groundtruth,
                                               masks[i])
+                # when prediction is a video
                 else:
                     result_sum = 0
                     for j in range(prediction.shape[0]):

--- a/mmeval/metrics/mae.py
+++ b/mmeval/metrics/mae.py
@@ -53,10 +53,19 @@ class MeanAbsoluteError(BaseMetric):
                 f'Image shapes are different: \
                     {groundtruth.shape}, {prediction.shape}.')
             if masks is None:
-                self._results.append(self.compute_mae(prediction, groundtruth))
+                result = self.compute_mae(prediction, groundtruth)
             else:
-                self._results.append(
-                    self.compute_mae(prediction, groundtruth, masks[i]))
+                if len(prediction.shape) <= 3:
+                    result = self.compute_mae(prediction, groundtruth,
+                                              masks[i])
+                else:
+                    result_sum = 0
+                    for j in range(prediction.shape[0]):
+                        result_sum += self.compute_mae(prediction[j],
+                                                       groundtruth[j],
+                                                       masks[i][j])
+                    result = result_sum / prediction.shape[0]
+            self._results.append(result)
 
     def compute_metric(self, results: List[np.float32]) -> Dict[str, float]:
         """Compute the MeanAbsoluteError metric.

--- a/mmeval/metrics/mse.py
+++ b/mmeval/metrics/mse.py
@@ -52,10 +52,19 @@ class MeanSquaredError(BaseMetric):
                 f'Image shapes are different: \
                     {groundtruth.shape}, {prediction.shape}.')
             if masks is None:
-                self._results.append(self.compute_mse(prediction, groundtruth))
+                result = self.compute_mse(prediction, groundtruth)
             else:
-                self._results.append(
-                    self.compute_mse(prediction, groundtruth, masks[i]))
+                if len(prediction.shape) <= 3:
+                    result = self.compute_mse(prediction, groundtruth,
+                                              masks[i])
+                else:
+                    result_sum = 0
+                    for j in range(prediction.shape[0]):
+                        result_sum += self.compute_mse(prediction[j],
+                                                       groundtruth[j],
+                                                       masks[i][j])
+                    result = result_sum / prediction.shape[0]
+            self._results.append(result)
 
     def compute_metric(self, results: List[np.float32]) -> Dict[str, float]:
         """Compute the MeanSquaredError metric.

--- a/mmeval/metrics/mse.py
+++ b/mmeval/metrics/mse.py
@@ -54,9 +54,11 @@ class MeanSquaredError(BaseMetric):
             if masks is None:
                 result = self.compute_mse(prediction, groundtruth)
             else:
+                # when prediction is a image
                 if len(prediction.shape) <= 3:
                     result = self.compute_mse(prediction, groundtruth,
                                               masks[i])
+                # when prediction is a video
                 else:
                     result_sum = 0
                     for j in range(prediction.shape[0]):

--- a/mmeval/metrics/psnr.py
+++ b/mmeval/metrics/psnr.py
@@ -92,15 +92,22 @@ class PeakSignalNoiseRatio(BaseMetric):
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
             prediction = reorder_and_crop(
                 prediction,
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
 
-            self._results.append(self.compute_psnr(prediction, groundtruth))
+            if len(prediction.shape) == 3:
+                prediction = np.expand_dims(prediction, axis=0)
+                groundtruth = np.expand_dims(groundtruth, axis=0)
+            _psnr_score = []
+            for i in range(prediction.shape[0]):
+                _psnr_score.append(
+                    self.compute_psnr(prediction[i], groundtruth[i]))
+            self._results.append(np.array(_psnr_score).mean())
 
     def compute_metric(self, results: List[np.float64]) -> Dict[str, float]:
         """Compute the PeakSignalNoiseRatio metric.

--- a/mmeval/metrics/snr.py
+++ b/mmeval/metrics/snr.py
@@ -82,23 +82,31 @@ class SignalNoiseRatio(BaseMetric):
         """
         channel_order = self.channel_order \
             if channel_order is None else channel_order
-        for pred, gt in zip(predictions, groundtruths):
-            assert gt.shape == pred.shape, (
-                f'Image shapes are different: {gt.shape}, {pred.shape}.')
-            gt = reorder_and_crop(
-                gt,
+        for prediction, groundtruth in zip(predictions, groundtruths):
+            assert groundtruth.shape == prediction.shape, (
+                f'Image shapes are different: \
+                    {groundtruth.shape}, {prediction.shape}.')
+            groundtruth = reorder_and_crop(
+                groundtruth,
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
-            pred = reorder_and_crop(
-                pred,
+                channel_order=channel_order)
+            prediction = reorder_and_crop(
+                prediction,
                 crop_border=self.crop_border,
                 input_order=self.input_order,
                 convert_to=self.convert_to,
-                channel_order=self.channel_order)
+                channel_order=channel_order)
 
-            self._results.append(self.compute_snr(pred, gt))
+            if len(prediction.shape) == 3:
+                prediction = np.expand_dims(prediction, axis=0)
+                groundtruth = np.expand_dims(groundtruth, axis=0)
+            _psnr_score = []
+            for i in range(prediction.shape[0]):
+                _psnr_score.append(
+                    self.compute_snr(prediction[i], groundtruth[i]))
+            self._results.append(np.array(_psnr_score).mean())
 
     def compute_metric(self, results: List[np.float64]) -> Dict[str, float]:
         """Compute the SignalNoiseRatio metric.

--- a/mmeval/metrics/snr.py
+++ b/mmeval/metrics/snr.py
@@ -102,11 +102,11 @@ class SignalNoiseRatio(BaseMetric):
             if len(prediction.shape) == 3:
                 prediction = np.expand_dims(prediction, axis=0)
                 groundtruth = np.expand_dims(groundtruth, axis=0)
-            _psnr_score = []
+            _snr_score = []
             for i in range(prediction.shape[0]):
-                _psnr_score.append(
+                _snr_score.append(
                     self.compute_snr(prediction[i], groundtruth[i]))
-            self._results.append(np.array(_psnr_score).mean())
+            self._results.append(np.array(_snr_score).mean())
 
     def compute_metric(self, results: List[np.float64]) -> Dict[str, float]:
         """Compute the SignalNoiseRatio metric.

--- a/mmeval/metrics/ssim.py
+++ b/mmeval/metrics/ssim.py
@@ -123,10 +123,10 @@ class StructuralSimilarity(BaseMetric):
                 pred = np.expand_dims(pred, axis=0)
                 gt = np.expand_dims(gt, axis=0)
             _ssim_score = []
-            for i in range(pred.shape[3]):
-                for j in range(pred.shape[0]):
+            for i in range(pred.shape[0]):
+                for j in range(pred.shape[3]):
                     _ssim_score.append(
-                        self.compute_ssim(pred[j][..., i], gt[j][..., i]))
+                        self.compute_ssim(pred[i][..., j], gt[i][..., j]))
             self._results.append(np.array(_ssim_score).mean())
 
     def compute_metric(self, results: List[np.float64]) -> Dict[str, float]:

--- a/mmeval/metrics/ssim.py
+++ b/mmeval/metrics/ssim.py
@@ -119,9 +119,14 @@ class StructuralSimilarity(BaseMetric):
                 convert_to=self.convert_to,
                 channel_order=channel_order)
 
+            if len(pred.shape) == 3:
+                pred = np.expand_dims(pred, axis=0)
+                gt = np.expand_dims(gt, axis=0)
             _ssim_score = []
-            for i in range(pred.shape[2]):
-                _ssim_score.append(self.compute_ssim(pred[..., i], gt[..., i]))
+            for i in range(pred.shape[3]):
+                for j in range(pred.shape[0]):
+                    _ssim_score.append(
+                        self.compute_ssim(pred[j][..., i], gt[j][..., i]))
             self._results.append(np.array(_ssim_score).mean())
 
     def compute_metric(self, results: List[np.float64]) -> Dict[str, float]:

--- a/mmeval/metrics/utils/image_transforms.py
+++ b/mmeval/metrics/utils/image_transforms.py
@@ -183,6 +183,14 @@ def reorder_and_crop(img: np.ndarray,
         np.array: The transformation results.
     """
 
+    if len(img.shape) == 4:
+        result = []
+        for i in range(img.shape[0]):
+            result.append(
+                reorder_and_crop(img[i], crop_border, input_order, convert_to,
+                                 channel_order))
+        return np.array(result).astype(np.float64)
+
     img = reorder_image(img, input_order=input_order)
     img = img.astype(np.float32)
 

--- a/tests/test_metrics/test_mae.py
+++ b/tests/test_metrics/test_mae.py
@@ -5,10 +5,27 @@ from mmeval.metrics import MeanAbsoluteError
 
 
 def test_mae():
+    # test image input
     preds = [np.ones((32, 32, 3))]
     gts = [np.ones((32, 32, 3)) * 2]
     mask = np.ones((32, 32, 3)) * 2
     mask[:16] *= 0
+
+    mae = MeanAbsoluteError()
+    mae_results = mae(preds, gts)
+    assert isinstance(mae_results, dict)
+    np.testing.assert_almost_equal(mae_results['mae'], 0.003921568627)
+
+    mae = MeanAbsoluteError()
+    mae_results = mae(preds, gts, [mask])
+    assert isinstance(mae_results, dict)
+    np.testing.assert_almost_equal(mae_results['mae'], 0.003921568627)
+
+    # test video input
+    preds = [np.ones((5, 32, 32, 3))]
+    gts = [np.ones((5, 32, 32, 3)) * 2]
+    mask = np.ones((5, 32, 32, 3)) * 2
+    mask[:, :16] *= 0
 
     mae = MeanAbsoluteError()
     mae_results = mae(preds, gts)

--- a/tests/test_metrics/test_mse.py
+++ b/tests/test_metrics/test_mse.py
@@ -5,10 +5,27 @@ from mmeval.metrics import MeanSquaredError
 
 
 def test_mse():
+    # test image input
     preds = [np.ones((32, 32, 3))]
     gts = [np.ones((32, 32, 3)) * 2]
     mask = np.ones((32, 32, 3)) * 2
     mask[:16] *= 0
+
+    mse = MeanSquaredError()
+    mse_results = mse(preds, gts)
+    assert isinstance(mse_results, dict)
+    np.testing.assert_almost_equal(mse_results['mse'], 0.000015378700496)
+
+    mse = MeanSquaredError()
+    mse_results = mse(preds, gts)
+    assert isinstance(mse_results, dict)
+    np.testing.assert_almost_equal(mse_results['mse'], 0.000015378700496)
+
+    # test video input
+    preds = [np.ones((5, 32, 32, 3))]
+    gts = [np.ones((5, 32, 32, 3)) * 2]
+    mask = np.ones((5, 32, 32, 3)) * 2
+    mask[:, :16] *= 0
 
     mse = MeanSquaredError()
     mse_results = mse(preds, gts)

--- a/tests/test_metrics/test_psnr.py
+++ b/tests/test_metrics/test_psnr.py
@@ -53,7 +53,9 @@ def test_psnr_init():
                }, [np.ones((32, 32, 3))], [np.ones(
                    (32, 32, 3)) * 2], 49.45272242415597),
                ({}, [np.ones((32, 32))], [np.ones((32, 32))], float('inf')),
-               ({}, [np.zeros((32, 32))], [np.ones((32, 32)) * 255], 0)])
+               ({}, [np.zeros((32, 32))], [np.ones((32, 32)) * 255], 0),
+               ({}, [np.ones((5, 3, 32, 32))], [np.ones(
+                   (5, 3, 32, 32)) * 2], 48.1308036086791)])
 def test_psnr(metric_kwargs, img1, img2, results):
     psnr = PeakSignalNoiseRatio(**metric_kwargs)
     psnr_results = psnr(img1, img2)

--- a/tests/test_metrics/test_snr.py
+++ b/tests/test_metrics/test_snr.py
@@ -39,7 +39,9 @@ def test_snr_init():
         ({'input_order': 'HWC', 'convert_to': 'Y'}, [np.ones((32, 32, 3))],
          [np.ones((32, 32, 3)) * 2], 26.290039980499536),
         ({}, [np.ones((32, 32))], [np.ones((32, 32))], float('inf')),
-        ({}, [np.zeros((32, 32))], [np.ones((32, 32))], 0)
+        ({}, [np.zeros((32, 32))], [np.ones((32, 32))], 0),
+        ({}, [np.ones((5, 3, 32, 32))], [np.ones((5, 3, 32, 32)) * 2],
+         6.020599913279624)
     ]
 )
 def test_snr(metric_kwargs, img1, img2, results):

--- a/tests/test_metrics/test_ssim.py
+++ b/tests/test_metrics/test_ssim.py
@@ -37,6 +37,8 @@ def test_ssim_init():
          [np.ones((3, 32, 32)) * 2], 0.9130623),
         ({'convert_to': 'Y', 'input_order': 'HWC'}, [np.ones((32, 32, 3))],
          [np.ones((32, 32, 3)) * 2], 0.9987801),
+        ({}, [np.ones((5, 3, 32, 32))], [np.ones((5, 3, 32, 32)) * 2],
+         0.9130623)
     ]
 )
 def test_ssim(metric_kwargs, img1, img2, results):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

psnr,snr,ssim,mae and mse fail to compute on videos.

## Modification

1. psnr,snr,ssim,mae and mse can process inputs with shape [t, h, w, c]
2. `img_transforms/reorder_and_crop` can process inputs with shape [t, h, w, c]

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
5. The documentation has been modified accordingly, like docstring or example tutorials.
