### PR TITLE
[Fix] CircleCI fail due to plum-dispatch v2.0.0

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,3 @@
 numpy
-plum-dispatch
+plum-dispatch<2.0.0
 pyyaml


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`plum-dispatch` bumps to version 2.0.0 yesterday, which breaks our unittests. There are 2 issues:

### 1. name 'xxx' is not defined

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/112053249/223354460-212e75f6-7a2e-4d2f-be5b-e8a9c4d56aab.png">

Reson: Still under investigation.

### 2. TypeError: unhashable type: 'list'

<img width="967" alt="image" src="https://user-images.githubusercontent.com/112053249/223355771-21a04529-ebb7-47bf-aff0-e7ebe19230b2.png">

Reason: `plum-dispatch` 2.0.0 migrates to use `beartype`, while `beartype` doesn't support Python 3.9.1. This is actually a [CPython error](https://bugs.python.org/issue42965) fixed in Python 3.9.2.

## Modification

Restrict `plum-dispatch<2.0.0` in requirements. Once fixed, will remove the version restriction.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
6. The documentation has been modified accordingly, like docstring or example tutorials.
