### PR TITLE
append faster-coco-eval as base backend for COCODetection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
         type: string
       paddle:
         type: string
-        default: "2.2.2"
+        default: "2.3.2"
       tensorflow:
         type: string
         default: "2.4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,96 +108,103 @@ jobs:
           command: |
             mpirun -np 2 pytest -vv --capture=no --with-mpi tests/test_core/test_dist_backends
 
-  build_cu112:
+  build_cuda:
+    parameters:
+      torch:
+        type: string
+      cuda:
+        type: enum
+        enum: ["11.7", "11.8"]
+      cudnn:
+        type: integer
+        default: 8
     machine:
-      image: ubuntu-2004-cuda-11.2:202103-01
-    resource_class: gpu.nvidia.small
+      image: linux-cuda-11:default
+      # docker_layer_caching: true
+    resource_class: gpu.nvidia.small.multi
     steps:
       - checkout
       - run:
-          # CUDNN is required for Paddle to use GPU, otherwise, the test cases will report an error.
-          name: Install CUDNN
+          # CLoning repos in VM since Docker doesn't have access to the private key
+          name: Clone Repos
           command: |
-            OS=ubuntu2004
-            cudnn_version=8.1.0.77
-            cuda_version=cuda11.2
-            wget https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-${OS}.pin
-            sudo mv cuda-${OS}.pin /etc/apt/preferences.d/cuda-repository-pin-600
-            sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/3bf863cc.pub
-            sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/ /"
+            git clone -b main --depth 1 ssh://git@github.com/open-mmlab/mmengine.git /home/circleci/mmengine
+      - run:
+          name: Install nvidia-container-toolkit and Restart Docker
+          command: |
             sudo apt-get update
-            sudo apt-get install libcudnn8=${cudnn_version}-1+${cuda_version}
-            sudo apt-get install libcudnn8-dev=${cudnn_version}-1+${cuda_version}
+            sudo apt-get install -y nvidia-container-toolkit
+            sudo systemctl restart docker
       - run:
-          name: Install PyTorch, Paddle and OneFlow via pip
+          name: Build Docker image
           command: |
-            pyenv global 3.9.2
-            pip install --upgrade pip
-            python -V
-            pip install torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html
-            pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
-            # Install Oneflow often failed, we just skip it if failed.
-            pip install --pre oneflow -f https://staging.oneflow.info/branch/master/cu112 "numpy<1.24.0" || true
+            docker build .circleci/docker -t mmeval:gpu --build-arg PYTORCH=<< parameters.torch >> --build-arg CUDA=<< parameters.cuda >> --build-arg CUDNN=<< parameters.cudnn >>
+            docker run --gpus all -t -d -v /home/circleci/project:/mmeval -v /home/circleci/mmengine:/mmengine -w /mmeval --name mmeval mmeval:gpu
+            docker exec mmeval apt-get install -y git
       - run:
-          name: Install mmeval and dependencies
+          name: Install mmeval dependencies
           command: |
-            pip install -r requirements/tests.txt
-            pip install -r requirements/optional.txt
-            pip install -e .
+            docker exec mmeval pip install paddlepaddle-gpu==2.3.2.post112 -f https://www.paddlepaddle.org.cn/whl/linux/mkl/avx/stable.html
+            docker exec mmeval pip install -r requirements/tests.txt
+            docker exec mmeval pip install -r requirements/optional.txt
+      - run:
+          name: Build and install
+          command: |
+            docker exec mmeval pip install -e .
       - run:
           name: Run unittests
           command: |
-            pytest -vv tests/
-
+            docker exec mmeval python -m pytest -vv tests/
 
 workflows:
   unit_tests:
     jobs:
       - lint
-      - build_cpu:
-          name: build_cpu_torch1.6_tf2.4
-          torch: 1.6.0
-          tensorflow: "2.4"
-          requires:
-            - lint
-      - build_cpu:
-          name: build_cpu_torch1.7_tf_2.6
-          torch: 1.7.0
-          tensorflow: "2.6"
-          requires:
-            - lint
-      - build_cpu:
-          name: build_cpu_torch1.8_tf2.7_py3.9
-          torch: 1.8.0
-          python: "3.9.0"
-          tensorflow: "2.7"
-          requires:
-            - lint
-      - build_cpu:
-          name: build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
-          torch: 1.9.0
-          paddle: 2.3.2
-          tensorflow: "2.8"
-          python: "3.8.12"
-          requires:
-            - lint
-      - build_cpu:
-          name: build_cpu_torch1.9_paddle2.10_py3.9
-          torch: 1.9.0
-          paddle: 2.4.0rc0
-          tensorflow: "2.10"
-          python: "3.9.0"
-          requires:
-            - lint
-      - build_mpirun_and_tf:
-          name: build_mpirun_and_tf_2.7
-          tensorflow: "2.7"
-          requires:
-            - build_cpu_torch1.6_tf2.4
-            - build_cpu_torch1.7_tf_2.6
-            - build_cpu_torch1.8_tf2.7_py3.9
-            - build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
-            - build_cpu_torch1.9_paddle2.10_py3.9
-      - build_cu112:
-          requires:
-            - build_mpirun_and_tf_2.7
+      # - build_cpu:
+      #     name: build_cpu_torch1.6_tf2.4
+      #     torch: 1.6.0
+      #     tensorflow: "2.4"
+      #     requires:
+      #       - lint
+      # - build_cpu:
+      #     name: build_cpu_torch1.7_tf_2.6
+      #     torch: 1.7.0
+      #     tensorflow: "2.6"
+      #     requires:
+      #       - lint
+      # - build_cpu:
+      #     name: build_cpu_torch1.8_tf2.7_py3.9
+      #     torch: 1.8.0
+      #     python: "3.9.0"
+      #     tensorflow: "2.7"
+      #     requires:
+      #       - lint
+      # - build_cpu:
+      #     name: build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
+      #     torch: 1.9.0
+      #     paddle: 2.3.2
+      #     tensorflow: "2.8"
+      #     python: "3.8.12"
+      #     requires:
+      #       - lint
+      # - build_cpu:
+      #     name: build_cpu_torch1.9_paddle2.10_py3.9
+      #     torch: 1.9.0
+      #     paddle: 2.4.0rc0
+      #     tensorflow: "2.10"
+      #     python: "3.9.0"
+      #     requires:
+      #       - lint
+      # - build_mpirun_and_tf:
+      #     name: build_mpirun_and_tf_2.7
+      #     tensorflow: "2.7"
+      #     requires:
+      #       - build_cpu_torch1.6_tf2.4
+      #       - build_cpu_torch1.7_tf_2.6
+      #       - build_cpu_torch1.8_tf2.7_py3.9
+      #       - build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
+      #       - build_cpu_torch1.9_paddle2.10_py3.9
+      - build_cuda:
+          name: build_cuda117_torch1.8_paddle2.3
+          torch: 1.8.1
+          cuda: "11.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
     machine:
       image: linux-cuda-11:default
       # docker_layer_caching: true
-    resource_class: gpu.nvidia.small.multi
+    resource_class: gpu.nvidia.small
     steps:
       - checkout
       - run:
@@ -208,3 +208,5 @@ workflows:
           name: build_cuda117_torch1.8_paddle2.3
           torch: 1.8.1
           cuda: "11.7"
+          requires:
+            - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,50 +160,50 @@ workflows:
   unit_tests:
     jobs:
       - lint
-      # - build_cpu:
-      #     name: build_cpu_torch1.6_tf2.4
-      #     torch: 1.6.0
-      #     tensorflow: "2.4"
-      #     requires:
-      #       - lint
-      # - build_cpu:
-      #     name: build_cpu_torch1.7_tf_2.6
-      #     torch: 1.7.0
-      #     tensorflow: "2.6"
-      #     requires:
-      #       - lint
-      # - build_cpu:
-      #     name: build_cpu_torch1.8_tf2.7_py3.9
-      #     torch: 1.8.0
-      #     python: "3.9.0"
-      #     tensorflow: "2.7"
-      #     requires:
-      #       - lint
-      # - build_cpu:
-      #     name: build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
-      #     torch: 1.9.0
-      #     paddle: 2.3.2
-      #     tensorflow: "2.8"
-      #     python: "3.8.12"
-      #     requires:
-      #       - lint
-      # - build_cpu:
-      #     name: build_cpu_torch1.9_paddle2.10_py3.9
-      #     torch: 1.9.0
-      #     paddle: 2.4.0rc0
-      #     tensorflow: "2.10"
-      #     python: "3.9.0"
-      #     requires:
-      #       - lint
-      # - build_mpirun_and_tf:
-      #     name: build_mpirun_and_tf_2.7
-      #     tensorflow: "2.7"
-      #     requires:
-      #       - build_cpu_torch1.6_tf2.4
-      #       - build_cpu_torch1.7_tf_2.6
-      #       - build_cpu_torch1.8_tf2.7_py3.9
-      #       - build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
-      #       - build_cpu_torch1.9_paddle2.10_py3.9
+      - build_cpu:
+          name: build_cpu_torch1.6_tf2.4
+          torch: 1.6.0
+          tensorflow: "2.4"
+          requires:
+            - lint
+      - build_cpu:
+          name: build_cpu_torch1.7_tf_2.6
+          torch: 1.7.0
+          tensorflow: "2.6"
+          requires:
+            - lint
+      - build_cpu:
+          name: build_cpu_torch1.8_tf2.7_py3.9
+          torch: 1.8.0
+          python: "3.9.0"
+          tensorflow: "2.7"
+          requires:
+            - lint
+      - build_cpu:
+          name: build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
+          torch: 1.9.0
+          paddle: 2.3.2
+          tensorflow: "2.8"
+          python: "3.8.12"
+          requires:
+            - lint
+      - build_cpu:
+          name: build_cpu_torch1.9_paddle2.10_py3.9
+          torch: 1.9.0
+          paddle: 2.4.0rc0
+          tensorflow: "2.10"
+          python: "3.9.0"
+          requires:
+            - lint
+      - build_mpirun_and_tf:
+          name: build_mpirun_and_tf_2.7
+          tensorflow: "2.7"
+          requires:
+            - build_cpu_torch1.6_tf2.4
+            - build_cpu_torch1.7_tf_2.6
+            - build_cpu_torch1.8_tf2.7_py3.9
+            - build_cpu_torch1.9_paddle2.3_tf2.8_py3.8
+            - build_cpu_torch1.9_paddle2.10_py3.9
       - build_cuda:
           name: build_cuda117_torch1.8_paddle2.3
           torch: 1.8.1

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,0 +1,11 @@
+ARG PYTORCH="1.8.1"
+ARG CUDA="10.2"
+ARG CUDNN="7"
+
+FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
+
+# To fix GPG key error when running apt-get update
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+RUN apt-get update && apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx

--- a/.pre-commit-config-zh-cn.yaml
+++ b/.pre-commit-config-zh-cn.yaml
@@ -54,9 +54,10 @@ repos:
       - id: check-copyright
         args: ["mmeval"]
   - repo: https://gitee.com/openmmlab/mirrors-mypy
-    rev: v0.812
+    rev: v0.981
     hooks:
       - id: mypy
+        additional_dependencies: ["types-setuptools", "types-PyYAML"] # error: Library stubs not installed for "yaml" (or incompatible with Python 3.10)
         exclude: |-
           (?x)(
               ^test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,9 +54,10 @@ repos:
       - id: check-copyright
         args: ["mmeval"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.981
     hooks:
       - id: mypy
+        additional_dependencies: ["types-setuptools", "types-PyYAML"] # error: Library stubs not installed for "yaml" (or incompatible with Python 3.10)
         exclude: |-
           (?x)(
               ^test

--- a/mmeval/fileio/io.py
+++ b/mmeval/fileio/io.py
@@ -435,8 +435,8 @@ def load(file, file_format=None, backend_args=None, **kwargs):
                 with StringIO(file_backend.get_text(file)) as f:
                     obj = handler.load_from_fileobj(f, **kwargs)
             except FileNotFoundError as e:
-                raise FileNotFoundError(
-                    f'{file=} {handler=} {file_format=} {e=}')
+                raise FileNotFoundError('{} {} {} {}'.format(
+                    file, handler, file_format, e))
         else:
             with BytesIO(file_backend.get(file)) as f:
                 obj = handler.load_from_fileobj(f, **kwargs)

--- a/mmeval/fileio/io.py
+++ b/mmeval/fileio/io.py
@@ -424,7 +424,7 @@ def load(file, file_format=None, backend_args=None, **kwargs):
         file = str(file)
     if file_format is None and isinstance(file, str):
         file_format = file.split('.')[-1]
-    if file_handlers.get(file_format) is None:
+    if file_format not in file_handlers:
         raise TypeError(f'Unsupported format: {file_format}')
 
     handler = file_handlers[file_format]

--- a/mmeval/fileio/io.py
+++ b/mmeval/fileio/io.py
@@ -431,8 +431,11 @@ def load(file, file_format=None, backend_args=None, **kwargs):
     if isinstance(file, str):
         file_backend = get_file_backend(file, backend_args=backend_args)
         if handler.str_like:
-            with StringIO(file_backend.get_text(file)) as f:
-                obj = handler.load_from_fileobj(f, **kwargs)
+            try:
+                with StringIO(file_backend.get_text(file)) as f:
+                    obj = handler.load_from_fileobj(f, **kwargs)
+            except FileNotFoundError as e:
+                raise FileNotFoundError(f"{file=} {handler=} {file_format=} {e=}")
         else:
             with BytesIO(file_backend.get(file)) as f:
                 obj = handler.load_from_fileobj(f, **kwargs)

--- a/mmeval/fileio/io.py
+++ b/mmeval/fileio/io.py
@@ -424,7 +424,7 @@ def load(file, file_format=None, backend_args=None, **kwargs):
         file = str(file)
     if file_format is None and isinstance(file, str):
         file_format = file.split('.')[-1]
-    if file_format not in file_handlers:
+    if file_handlers.get(file_format) is None:
         raise TypeError(f'Unsupported format: {file_format}')
 
     handler = file_handlers[file_format]

--- a/mmeval/fileio/io.py
+++ b/mmeval/fileio/io.py
@@ -435,7 +435,8 @@ def load(file, file_format=None, backend_args=None, **kwargs):
                 with StringIO(file_backend.get_text(file)) as f:
                     obj = handler.load_from_fileobj(f, **kwargs)
             except FileNotFoundError as e:
-                raise FileNotFoundError(f"{file=} {handler=} {file_format=} {e=}")
+                raise FileNotFoundError(
+                    f'{file=} {handler=} {file_format=} {e=}')
         else:
             with BytesIO(file_backend.get(file)) as f:
                 obj = handler.load_from_fileobj(f, **kwargs)

--- a/mmeval/metrics/coco_detection.py
+++ b/mmeval/metrics/coco_detection.py
@@ -24,7 +24,8 @@ except ImportError:
     HAS_COCOAPI = False
 
 try:
-    from mmeval.metrics.utils.faster_coco_wrapper import FasterCOCO, FasterCOCOeval
+    from mmeval.metrics.utils.faster_coco_wrapper import (FasterCOCO,
+                                                          FasterCOCOeval)
     HAS_FasterCOCOAPI = True
 except ImportError:
     HAS_FasterCOCOAPI = False

--- a/mmeval/metrics/coco_detection.py
+++ b/mmeval/metrics/coco_detection.py
@@ -177,14 +177,15 @@ class COCODetection(BaseMetric):
                                '`mmeval.utils.coco_wrapper`. '
                                'Please try to install official pycocotools by '
                                '"pip install pycocotools"')
-        
+
         if faster and not HAS_FasterCOCOAPI:
-            warnings.warn('Failed to import `FasterCOCO` and `FasterCOCOeval` from '
-                               '`mmeval.utils.faster_coco_wrapper`. '
-                               'Please try to install official faster-coco-eval by '
-                               '"pip install faster-coco-eval"')
+            warnings.warn(
+                'Failed to import `FasterCOCO` and `FasterCOCOeval` from '
+                '`mmeval.utils.faster_coco_wrapper`. '
+                'Please try to install official faster-coco-eval by '
+                '"pip install faster-coco-eval"')
             faster = False
-        
+
         super().__init__(**kwargs)
         # coco evaluation metrics
         self.metrics = metric if isinstance(metric, list) else [metric]
@@ -531,7 +532,7 @@ class COCODetection(BaseMetric):
             self.logger.info('Converting ground truth to coco format...')
             coco_json_path = self.gt_to_coco_json(
                 gt_dicts=gts, outfile_prefix=outfile_prefix)
-            
+
             if self.faster:
                 self._coco_api = FasterCOCO(coco_json_path)
             else:

--- a/mmeval/metrics/utils/faster_coco_wrapper.py
+++ b/mmeval/metrics/utils/faster_coco_wrapper.py
@@ -1,10 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from faster_coco_eval import COCO as _COCO
 from faster_coco_eval import COCOeval_faster as _faster_COCOeval
+
 from mmeval.metrics.utils.coco_wrapper import COCO
 
+
 class FasterCOCO(COCO, _COCO):
-    """This class is almost the same as official pycocotools package and faster-coco-eval package.
+    """This class is almost the same as official pycocotools package and
+    faster-coco-eval package.
 
     It implements some snake case function aliases. So that the COCO class has
     the same interface as LVIS class.
@@ -13,6 +16,7 @@ class FasterCOCO(COCO, _COCO):
         annotation_file (str, optional): Path of annotation file.
             Defaults to None.
     """
+
 
 # just for the ease of import
 FasterCOCOeval = _faster_COCOeval

--- a/mmeval/metrics/utils/faster_coco_wrapper.py
+++ b/mmeval/metrics/utils/faster_coco_wrapper.py
@@ -1,0 +1,18 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from faster_coco_eval import COCO as _COCO
+from faster_coco_eval import COCOeval_faster as _faster_COCOeval
+from mmeval.metrics.utils.coco_wrapper import COCO
+
+class FasterCOCO(COCO, _COCO):
+    """This class is almost the same as official pycocotools package and faster-coco-eval package.
+
+    It implements some snake case function aliases. So that the COCO class has
+    the same interface as LVIS class.
+
+    Args:
+        annotation_file (str, optional): Path of annotation file.
+            Defaults to None.
+    """
+
+# just for the ease of import
+FasterCOCOeval = _faster_COCOeval

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,3 @@
 pycocotools
+faster-coco-eval
 shapely

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
+faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@dev
 pycocotools
 shapely
-faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@dev

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
-faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@main
+faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@dev
 pycocotools
 shapely

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
-faster-coco-eval
+faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@main
 pycocotools
 shapely

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
-pycocotools
 faster-coco-eval
+pycocotools
 shapely

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
-faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@dev
 pycocotools
 shapely
+faster-coco-eval @ git+https://github.com/MiXaiLL76/faster_coco_eval@dev

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>1.20.1
 plum-dispatch<2.0.0
 pyyaml
 rich

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-numpy>1.20.1
+numpy
 plum-dispatch<2.0.0
 pyyaml
 rich

--- a/tests/test_fileio/test_io.py
+++ b/tests/test_fileio/test_io.py
@@ -315,7 +315,7 @@ def test_list_dir_or_file():
 def test_load():
     # invalid file format
     with pytest.raises(TypeError, match='Unsupported format'):
-        fileio.load('filename.txt')
+        fileio.load('filename.ttx')
 
     # file is not a valid input
     with pytest.raises(


### PR DESCRIPTION
<https://github.com/MiXaiLL76/faster_coco_eval>

## Motivation

I often use this project, but I saw it abandoned and without a public repository on github. Also, part of the project remained unfinished for a long time. I implemented some of the author's ideas and decided to make the results publicly available.

## Modification

This implementation greatly speeds up the evaluation time for coco's AP metrics, especially when dealing with a high number of instances in an image.

## Use cases

```py
COCODetection(..., faster=True)
```

| Type | COCOeval    | COCOeval_faster | Profit      |
| ---- | ----------- | --------------- | ----------- |
| bbox | 18.477 sec. | 7.345 sec.      | 2.5x faster |
| segm | 29.819 sec. | 15.840 sec.     | 2x faster   |
